### PR TITLE
fix/folders with filesystem separators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ setup:
 	$(MAKE) -C ./cli setup && \
 	$(MAKE) -C ./core setup
 
+.PHONY: build
 build: go-imapgrab
 
 go-imapgrab: */*.go

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -7,6 +7,7 @@ setup:
 	go mod download
 	go mod tidy
 
+.PHONY: build
 build: go-imapgrab
 
 go-imapgrab: *.go

--- a/core/core.go
+++ b/core/core.go
@@ -18,8 +18,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // Package core provides central functionality for backing up IMAP mailboxes.
 package core
 
-import "path/filepath"
-
 // IMAPConfig is a configuration needed to access an IMAP server.
 type IMAPConfig struct {
 	Server   string
@@ -73,9 +71,9 @@ func DownloadFolder(cfg IMAPConfig, folders []string, maildirBase string) error 
 
 	for _, folder := range folders {
 		oldmailFilePath := oldmailFileName(cfg, folder)
-		maildirPath := filepath.Join(maildirBase, folder)
+		maildirPath := maildirPathT{base: maildirBase, folder: folder}
 
-		err = downloadMissingEmailsToFolder(imapClient, folder, maildirPath, oldmailFilePath)
+		err = downloadMissingEmailsToFolder(imapClient, maildirPath, oldmailFilePath)
 		if err != nil {
 			return err
 		}

--- a/core/download.go
+++ b/core/download.go
@@ -134,13 +134,13 @@ func streamingDelivery(
 }
 
 func downloadMissingEmailsToFolder(
-	imapClient *client.Client, folder, maildirPath, oldmailName string,
+	imapClient *client.Client, maildirPath maildirPathT, oldmailName string,
 ) error {
 	oldmails, oldmailPath, err := initMaildir(oldmailName, maildirPath)
 	if err != nil {
 		return err
 	}
-	mbox, err := selectFolder(imapClient, folder)
+	mbox, err := selectFolder(imapClient, maildirPath.folderName())
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func downloadMissingEmailsToFolder(
 	}
 	// Download missing emails and store them on disk.
 	deliveredChan, deliverErrCount := streamingDelivery(
-		messageChan, maildirPath, uidvalidity, &wg, &startWg,
+		messageChan, maildirPath.folderPath(), uidvalidity, &wg, &startWg,
 	)
 	if err != nil {
 		return err

--- a/core/maildir.go
+++ b/core/maildir.go
@@ -112,30 +112,27 @@ func isMaildir(path string) bool {
 // existence of an oldmail file, parses it, and returns the information stored within it. It also
 // returns the path to that oldmail file.
 func initExistingMaildir(
-	oldmailName, maildirPath string,
+	oldmailName string, maildirPath maildirPathT,
 ) (oldmails []oldmail, oldmailFilePath string, err error) {
 	logInfo("retrieving information about emails stored on disk")
-	if len(maildirPath) == 0 {
+	folderPath := maildirPath.folderPath()
+	if len(folderPath) == 0 {
 		err = fmt.Errorf("path to maildir cannot be empty")
 		return
 	}
-	// Ensure the maildirPath has no trailing slashes and is generally as short as possible. This is
-	// often called canonicalisation.
-	maildirPath = filepath.Clean(maildirPath)
 
-	logInfo(fmt.Sprintf("checking for sub-directories of possible maildir %s", maildirPath))
-	if !isMaildir(maildirPath) {
-		err = fmt.Errorf("given directory %s does not point to a maildir", maildirPath)
+	logInfo(fmt.Sprintf("checking for sub-directories of possible maildir %s", folderPath))
+	if !isMaildir(folderPath) {
+		err = fmt.Errorf("given directory %s does not point to a maildir", folderPath)
 		return
 	}
 	logInfo("all sub-directories found")
 
 	// Extract expected maildirPath of oldmail file.
-	parent := filepath.Dir(maildirPath)
-	oldmailPath := filepath.Join(parent, oldmailName)
+	oldmailPath := filepath.Join(maildirPath.basePath(), oldmailName)
 
 	logInfo(
-		fmt.Sprintf("checking for and reading oldmail file of possible maildir %s", maildirPath),
+		fmt.Sprintf("checking for and reading oldmail file of possible maildir %s", folderPath),
 	)
 	oldmails, err = readOldmail(oldmailPath)
 	if err != nil {
@@ -149,24 +146,25 @@ func initExistingMaildir(
 // Initialize a maildir. If the given path already exists, only check whether the path is a maildir.
 // If not, create the path first including all the required sub-directories and an empty oldmail
 // file.
-func initMaildir(oldmailName, maildirPath string) ([]oldmail, string, error) {
+func initMaildir(oldmailName string, maildirPath maildirPathT) ([]oldmail, string, error) {
 	logInfo(fmt.Sprintf("initializing maildir %s", maildirPath))
+	basePath := maildirPath.basePath()
+	folderPath := maildirPath.folderPath()
 	// Replace each filesystem path separators by a dot. That way, we do not accidentally split
 	// paths where we do not want to, which would cause us not to find the oldmail file or the
 	// maildir.
 	oldmailName = strings.ReplaceAll(oldmailName, string(os.PathSeparator), ".")
-	if !isDir(maildirPath) {
-		logInfo(fmt.Sprintf("creating path to maildir %s and subdirectories", maildirPath))
-		err := os.MkdirAll(maildirPath, dirPerm)
+	if !isDir(folderPath) {
+		logInfo(fmt.Sprintf("creating path to maildir %s and subdirectories", folderPath))
+		err := os.MkdirAll(folderPath, dirPerm)
 		for _, dir := range []string{newMaildir, curMaildir, tmpMaildir} {
-			joined := filepath.Join(maildirPath, dir)
+			joined := filepath.Join(folderPath, dir)
 			if err == nil {
 				err = os.MkdirAll(joined, dirPerm)
 			}
 		}
 		if err == nil {
-			parent := filepath.Dir(maildirPath)
-			err = touch(filepath.Join(parent, oldmailName), filePerm)
+			err = touch(filepath.Join(basePath, oldmailName), filePerm)
 		}
 		if err != nil {
 			return []oldmail{}, "", err

--- a/core/maildir.go
+++ b/core/maildir.go
@@ -151,6 +151,10 @@ func initExistingMaildir(
 // file.
 func initMaildir(oldmailName, maildirPath string) ([]oldmail, string, error) {
 	logInfo(fmt.Sprintf("initializing maildir %s", maildirPath))
+	// Replace each filesystem path separators by a dot. That way, we do not accidentally split
+	// paths where we do not want to, which would cause us not to find the oldmail file or the
+	// maildir.
+	oldmailName = strings.ReplaceAll(oldmailName, string(os.PathSeparator), ".")
 	if !isDir(maildirPath) {
 		logInfo(fmt.Sprintf("creating path to maildir %s and subdirectories", maildirPath))
 		err := os.MkdirAll(maildirPath, dirPerm)

--- a/core/maildir_path.go
+++ b/core/maildir_path.go
@@ -1,0 +1,38 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import "path/filepath"
+
+// Type maildirPathT provides routines to manipulate paths that are required to handle maildirs.
+type maildirPathT struct {
+	base   string
+	folder string
+}
+
+func (p maildirPathT) basePath() string {
+	return filepath.Clean(p.base)
+}
+
+func (p maildirPathT) folderPath() string {
+	return filepath.Join(filepath.Clean(p.base), p.folder)
+}
+
+func (p maildirPathT) folderName() string {
+	return p.folder
+}


### PR DESCRIPTION
- Preliminary fix for folders with filesystem path sep in their name
- Fix download of folders containing system path separators
- Make build a phony target to allow quick retriggering
