### PR TITLE
Add login command

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,6 +7,7 @@ replace github.com/razziel89/go-imapgrab/core => ../core
 require (
 	github.com/razziel89/go-imapgrab/core v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.3.0
+	github.com/stretchr/testify v1.7.1
 	github.com/zalando/go-keyring v0.2.0
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/razziel89/go-imapgrab/core v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.3.0
 	github.com/zalando/go-keyring v0.2.0
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -535,7 +535,9 @@ golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211205182925-97ca703d548d h1:FjkYO/PPp4Wi0EAUOVLxePm7qVW4r4ctbWpURyuOD0E=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -250,8 +250,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -756,6 +758,7 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/cli/keyring.go
+++ b/cli/keyring.go
@@ -36,15 +36,17 @@ type keyringOps interface {
 }
 
 // Struct defaultKeyring is the production implementation of the interface for the keyring module.
-type defaultKeyring struct{}
+type defaultKeyringImpl struct{}
 
-func (dk defaultKeyring) Get(service string, user string) (string, error) {
+func (dk defaultKeyringImpl) Get(service string, user string) (string, error) {
 	return keyring.Get(service, user)
 }
 
-func (dk defaultKeyring) Set(service string, user string, password string) error {
+func (dk defaultKeyringImpl) Set(service string, user string, password string) error {
 	return keyring.Set(service, user, password)
 }
+
+var defaultKeyring keyringOps = &defaultKeyringImpl{}
 
 // Function keyringServiceSpec provides a strig identifying a service with all its possible
 // configuration components in the keyring.

--- a/cli/keyring.go
+++ b/cli/keyring.go
@@ -35,7 +35,8 @@ type keyringOps interface {
 	Set(service string, user string, password string) error
 }
 
-// Struct defaultKeyring is the production implementation of the interface for the keyring module.
+// Struct defaultKeyringImpl is the production implementation of the interface for the keyring
+// module.
 type defaultKeyringImpl struct{}
 
 func (dk defaultKeyringImpl) Get(service string, user string) (string, error) {

--- a/cli/keyring.go
+++ b/cli/keyring.go
@@ -57,29 +57,27 @@ func keyringServiceSpec(cfg rootConfigT) string {
 func retrieveFromKeyring(cfg rootConfigT, keyring keyringOps) (string, error) {
 	serviceSpec := keyringServiceSpec(cfg)
 	systemUserName, err := user.Current()
-	if err != nil {
-		return "", err
+
+	var secret string
+	if err == nil {
+		secret, err = keyring.Get(serviceSpec, systemUserName.Username)
 	}
 
-	secret, err := keyring.Get(serviceSpec, systemUserName.Username)
 	if err != nil {
-		return "", err
+		// Do not return anything that might have been retrieved in case of an error.
+		secret = ""
 	}
 
-	return secret, nil
+	return secret, err
 }
 
 func addToKeyring(cfg rootConfigT, password string, keyring keyringOps) error {
 	serviceSpec := keyringServiceSpec(cfg)
 	systemUserName, err := user.Current()
-	if err != nil {
-		return err
+
+	if err == nil {
+		err = keyring.Set(serviceSpec, systemUserName.Username, password)
 	}
 
-	err = keyring.Set(serviceSpec, systemUserName.Username, password)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/cli/keyring_test.go
+++ b/cli/keyring_test.go
@@ -1,0 +1,140 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockKeyring struct {
+	mock.Mock
+}
+
+func (mk *mockKeyring) Get(service string, user string) (string, error) {
+	args := mk.Called(service, user)
+	return args.String(0), args.Error(1)
+}
+
+func (mk *mockKeyring) Set(service string, user string, password string) error {
+	args := mk.Called(service, user, password)
+	return args.Error(0)
+}
+
+func TestKeyringServiceSpec(t *testing.T) {
+	cfg := rootConfigT{
+		server:   "some server",
+		port:     42,
+		username: "some user",
+		password: "will not be in spec",
+	}
+
+	spec := keyringServiceSpec(cfg)
+
+	assert.NotContains(t, spec, "will not be in spec")
+	assert.Contains(t, spec, "some server")
+	assert.Contains(t, spec, "some user")
+	assert.Contains(t, spec, "42")
+}
+
+func TestRetrieveFromKeyringSuccess(t *testing.T) {
+	cfg := rootConfigT{
+		server:   "server",
+		port:     42,
+		username: "user",
+		password: "i am not important",
+	}
+
+	user, err := user.Current()
+	assert.NoError(t, err)
+
+	mk := mockKeyring{}
+	mk.On("Get", "go-imapgrab/user@server:42", user.Username).Return("some password", nil)
+
+	password, err := retrieveFromKeyring(cfg, &mk)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "some password", password)
+	mk.AssertExpectations(t)
+}
+
+func TestRetrieveFromKeyringNoPassword(t *testing.T) {
+	cfg := rootConfigT{
+		server:   "server",
+		port:     42,
+		username: "user",
+		password: "i am not important",
+	}
+
+	user, err := user.Current()
+	assert.NoError(t, err)
+
+	mk := mockKeyring{}
+	mk.On("Get", "go-imapgrab/user@server:42", user.Username).Return("", fmt.Errorf("some error"))
+
+	password, err := retrieveFromKeyring(cfg, &mk)
+
+	assert.Error(t, err)
+	assert.Empty(t, password)
+	mk.AssertExpectations(t)
+}
+
+func TestAddToKeyringSuccess(t *testing.T) {
+	cfg := rootConfigT{
+		server:   "server",
+		port:     42,
+		username: "user",
+		password: "i will be added",
+	}
+
+	user, err := user.Current()
+	assert.NoError(t, err)
+
+	mk := mockKeyring{}
+	mk.On("Set", "go-imapgrab/user@server:42", user.Username, "i will be added").Return(nil)
+
+	err = addToKeyring(cfg, cfg.password, &mk)
+
+	assert.NoError(t, err)
+	mk.AssertExpectations(t)
+}
+
+func TestAddToKeyringError(t *testing.T) {
+	cfg := rootConfigT{
+		server:   "server",
+		port:     42,
+		username: "user",
+		password: "i will be added",
+	}
+
+	user, err := user.Current()
+	assert.NoError(t, err)
+
+	mk := mockKeyring{}
+	mk.On("Set", "go-imapgrab/user@server:42", user.Username, "i will be added").
+		Return(fmt.Errorf("some error"))
+
+	err = addToKeyring(cfg, cfg.password, &mk)
+
+	assert.Error(t, err)
+	mk.AssertExpectations(t)
+}

--- a/cli/login.go
+++ b/cli/login.go
@@ -1,0 +1,54 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/razziel89/go-imapgrab/core"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func init() {
+	rootCmd.AddCommand(loginCmd)
+}
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Store credentials in your system's keyring.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		core.SetVerboseLogs(verbose)
+
+		fmt.Printf(
+			"Please provide your password for the following service:\n"+
+				"  Username: %s\n  Server: %s\n  Port: %d\n\n"+
+				"Your password won't be echoed. "+
+				"You may need to reset your terminal after aborting with Ctrl+C.\n"+
+				"\nPassword:",
+			rootConf.username, rootConf.server, rootConf.port,
+		)
+		password, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+
+		return addToKeyring(rootConf, string(password), defaultKeyring)
+	},
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -77,14 +77,14 @@ func initCredentials() error {
 			return nil
 		}
 		logDebug("adding password to keyring")
-		return addToKeyring(rootConf, password, &defaultKeyring{})
+		return addToKeyring(rootConf, password, defaultKeyring)
 	}
 	if noKeyring {
 		return fmt.Errorf("password not set via env var IGRAB_PASSWORD and keyring disabled")
 	}
 	logDebug("password not set via env var IGRAB_PASSWORD, taking from keyring")
 	var err error
-	rootConf.password, err = retrieveFromKeyring(rootConf, &defaultKeyring{})
+	rootConf.password, err = retrieveFromKeyring(rootConf, defaultKeyring)
 	if err != nil {
 		return err
 	}

--- a/cli/root.go
+++ b/cli/root.go
@@ -77,14 +77,14 @@ func initCredentials() error {
 			return nil
 		}
 		logDebug("adding password to keyring")
-		return addToKeyring(rootConf, password)
+		return addToKeyring(rootConf, password, &defaultKeyring{})
 	}
 	if noKeyring {
 		return fmt.Errorf("password not set via env var IGRAB_PASSWORD and keyring disabled")
 	}
 	logDebug("password not set via env var IGRAB_PASSWORD, taking from keyring")
 	var err error
-	rootConf.password, err = retrieveFromKeyring(rootConf)
+	rootConf.password, err = retrieveFromKeyring(rootConf, &defaultKeyring{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a `login` command that allows the user to provide their password
without using an environment variable. This PR also adds tests for keyring
integration.

What was done:
- Abstract keyring away
- Add dependencies for login command
- Make commands that handle keyrings testable
- Add login command
- Add test dependencies
- Simplify keyring integration
- Add tests for keyring integration

This closes #35.