### PR TITLE
Fix completion output

### DIFF
--- a/cli/download.go
+++ b/cli/download.go
@@ -50,6 +50,9 @@ var downloadCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return initCredentials()
+	},
 }
 
 func init() {

--- a/cli/list.go
+++ b/cli/list.go
@@ -52,4 +52,7 @@ var listCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return initCredentials()
+	},
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -50,13 +50,10 @@ func logDebug(v ...interface{}) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "imapgrab",
+	Use:   "go-imapgrab",
 	Short: "Backup your IMAP-based email accounts with ease.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
-	},
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return initCredentials()
 	},
 }
 


### PR DESCRIPTION
Fix completion otuput by requiring the env var containing the password only for
those commands that actually require the password.

Closes #27.
