### PR TITLE
feature/improve abstraction use unit tests

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -11,7 +11,12 @@ setup:
 lint:
 	golangci-lint run .
 
-test: .test.log
+full-test:
+	touch go.mod
+	SKIP_INTEGRATION_TESTS=0 $(MAKE) .test.log
+
+test:
+	SKIP_INTEGRATION_TESTS=1 $(MAKE) .test.log
 
 .test.log: go.* *.go
 	set -o pipefail && \

--- a/core/core.go
+++ b/core/core.go
@@ -42,13 +42,18 @@ type ImapgrabOps interface {
 
 // Imapgrabber is the defailt implementation of ImapgrabOps.
 type Imapgrabber struct {
-	imapOps imapOps
+	downloadOps downloadOps
+	imapOps     imapOps
 }
 
 // authenticateClient is used to authenticate against a remote server
 func (ig *Imapgrabber) authenticateClient(cfg IMAPConfig) error {
 	imapOps, err := authenticateClient(cfg)
 	ig.imapOps = imapOps
+	ig.downloadOps = downloader{
+		imapOps:    imapOps,
+		deliverOps: deliverer{},
+	}
 	return err
 }
 
@@ -68,7 +73,7 @@ func (ig *Imapgrabber) getFolderList() ([]string, error) {
 func (ig *Imapgrabber) downloadMissingEmailsToFolder(
 	maildirPath maildirPathT, oldmailName string,
 ) error {
-	return downloadMissingEmailsToFolder(ig.imapOps, maildirPath, oldmailName)
+	return downloadMissingEmailsToFolder(ig.downloadOps, maildirPath, oldmailName)
 }
 
 // NewImapgrabOps creates a new instance of the default implementation of ImapgrabOps.

--- a/core/deliver.go
+++ b/core/deliver.go
@@ -1,0 +1,70 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import "sync"
+
+type deliverOps interface {
+	deliverMessage(string, string) error
+	rfc822FromEmail(emailOps, int) (string, oldmail, error)
+}
+
+type deliverer struct{}
+
+func (d deliverer) deliverMessage(text string, maildirPath string) error {
+	return deliverMessage(text, maildirPath)
+}
+
+func (d deliverer) rfc822FromEmail(msg emailOps, uidvalidity int) (string, oldmail, error) {
+	return rfc822FromEmail(msg, uidvalidity)
+}
+
+func streamingDelivery(
+	ops deliverOps,
+	messageChan <-chan emailOps,
+	maildirPath string,
+	uidvalidity int,
+	wg, stwg *sync.WaitGroup,
+) (returnedChan <-chan oldmail, errCountPtr *int) {
+	var errCount int
+
+	deliveredChan := make(chan oldmail, messageDeliveryBuffer)
+
+	wg.Add(1)
+	go func() {
+		// Do not start before the entire pipeline has been set up.
+		stwg.Wait()
+		for msg := range messageChan {
+			// Deliver each email to the `tmp` directory and move them to the `new` directory.
+			text, oldmail, err := ops.rfc822FromEmail(msg, uidvalidity)
+			if err == nil {
+				err = ops.deliverMessage(text, maildirPath)
+			}
+			if err != nil {
+				logError(err.Error())
+				errCount++
+				continue
+			}
+			deliveredChan <- oldmail
+		}
+		wg.Done()
+		close(deliveredChan)
+	}()
+
+	return deliveredChan, &errCount
+}

--- a/core/deliver_test.go
+++ b/core/deliver_test.go
@@ -1,0 +1,123 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockDeliverer struct {
+	mock.Mock
+}
+
+func (m *mockDeliverer) deliverMessage(text string, maildirPath string) error {
+	args := m.Called(text, maildirPath)
+	return args.Error(0)
+}
+
+func (m *mockDeliverer) rfc822FromEmail(msg emailOps, uidvalidity int) (string, oldmail, error) {
+	args := m.Called(msg, uidvalidity)
+	return args.String(0), args.Get(1).(oldmail), args.Error(2)
+}
+
+func TestDelivererDeliverMessage(t *testing.T) {
+	tmpdir := t.TempDir()
+	missingDir := filepath.Join(tmpdir, "some", "dir", "that", "surely", "does", "not", "exist")
+
+	deliverer := &deliverer{}
+	err := deliverer.deliverMessage("some text", missingDir)
+
+	assert.Error(t, err)
+}
+
+func TestDelivererRFC822FromEmail(t *testing.T) {
+	msg := &mockEmail{uid: 42}
+	msg.On("Format").Return([]interface{}{})
+
+	deliverer := &deliverer{}
+	_, _, err := deliverer.rfc822FromEmail(msg, 123)
+
+	assert.Error(t, err)
+	msg.AssertExpectations(t)
+}
+
+func TestStreamingDeliverySuccessDespiteOneError(t *testing.T) {
+	m := &mockDeliverer{}
+
+	mockEmails := []*mockEmail{}
+	for i := 0; i < 10; i++ {
+		msg := &mockEmail{uid: i}
+		mockEmails = append(mockEmails, msg)
+		om := oldmail{
+			uidValidity: 42,
+			uid:         i,
+			timestamp:   12345,
+		}
+		var formatErr error
+		if i == 5 {
+			formatErr = fmt.Errorf("some error")
+		}
+		m.On("rfc822FromEmail", msg, 42).Return("actual content", om, formatErr)
+		if formatErr == nil {
+			m.On("deliverMessage", "actual content", "/some/path").Return(nil)
+		}
+	}
+
+	// Set up goroutine providing input.
+	msgChan := make(chan emailOps)
+	go func() {
+		for _, msg := range mockEmails {
+			msgChan <- msg
+		}
+		close(msgChan)
+	}()
+
+	var wg, stwg sync.WaitGroup
+	// Delay actual operations until the entire pipeline has been set up.
+	stwg.Add(1)
+
+	uidvalidity := 42
+	maildir := "/some/path"
+
+	oldmailChan, errCountPtr := streamingDelivery(m, msgChan, maildir, uidvalidity, &wg, &stwg)
+	assert.Zero(t, *errCountPtr)
+
+	// Wait a while and check that nothing has happened yet.
+	time.Sleep(time.Millisecond * 100) // nolint: gomnd
+	m.AssertNotCalled(t, "rfc822FromEmail", mock.Anything, mock.Anything)
+	m.AssertNotCalled(t, "deliverMessage", mock.Anything, mock.Anything)
+
+	// Actually trigger operations and read from output channel.
+	stwg.Done()
+	oldmails := []oldmail{}
+	for om := range oldmailChan {
+		oldmails = append(oldmails, om)
+	}
+	wg.Wait()
+
+	m.AssertExpectations(t)
+	assert.Equal(t, 1, *errCountPtr)
+	assert.Equal(t, 9, len(oldmails))
+}

--- a/core/download_test.go
+++ b/core/download_test.go
@@ -18,349 +18,143 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package core
 
 import (
-	"bytes"
-	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/emersion/go-imap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestDetermineMissingIDsEmptyData(t *testing.T) {
-	oldmails := []oldmail{}
-	uids := []uid{}
-
-	ranges, err := determineMissingIDs(oldmails, uids)
-
-	assert.NoError(t, err)
-	assert.Equal(t, []rangeT{}, ranges)
+type mockDownloader struct {
+	messages      []*mockEmail
+	messageChan   chan emailOps
+	delivered     []oldmail
+	deliveredChan chan oldmail
+	t             *testing.T
+	mock.Mock
 }
 
-func TestDetermineMissingIDsEverythingDownloaded(t *testing.T) {
-	// The fields uidValidity and Mbox mean the same thing. The fields uid and Message also mean the
-	// same thing. The remote server identifies messages by their position in uids instead of their
-	// actual unique identifiers. Thus, it is important that the uids slice is not rearranged in any
-	// way.
-	oldmails := []oldmail{
-		// Note that UIDs start at 1 according to the return values of IMAP servers.
-		{uidValidity: 0, uid: 1, timestamp: 0},
-		{uidValidity: 0, uid: 2, timestamp: 0},
-		{uidValidity: 0, uid: 3, timestamp: 0},
-	}
-	uids := []uid{
-		{Mbox: 0, Message: 1},
-		{Mbox: 0, Message: 3}, // 3 and 2 swapped deliberately.
-		{Mbox: 0, Message: 2},
-	}
-	orgUIDs := make([]uid, len(uids))
-	_ = copy(orgUIDs, uids)
-
-	ranges, err := determineMissingIDs(oldmails, uids)
-
-	assert.NoError(t, err)
-	assert.Equal(t, orgUIDs, uids)
-	assert.Equal(t, []rangeT{}, ranges)
+func (m *mockDownloader) selectFolder(folder string) (*imap.MailboxStatus, error) {
+	args := m.Called(folder)
+	return args.Get(0).(*imap.MailboxStatus), args.Error(1)
 }
 
-func TestDetermineMissingIDsSomeMissing(t *testing.T) {
-	oldmails := []oldmail{
-		{uidValidity: 0, uid: 1, timestamp: 0},
-		{uidValidity: 0, uid: 2, timestamp: 0},
-		{uidValidity: 0, uid: 3, timestamp: 0},
-		{uidValidity: 0, uid: 4, timestamp: 0},
-	}
-	uids := []uid{
-		{Mbox: 0, Message: 1},
-		{Mbox: 0, Message: 5},
-		{Mbox: 0, Message: 6},
-	}
-	orgUIDs := make([]uid, len(uids))
-	_ = copy(orgUIDs, uids)
-
-	ranges, err := determineMissingIDs(oldmails, uids)
-
-	assert.NoError(t, err)
-	assert.Equal(t, orgUIDs, uids)
-	// This means that the emails that are located in the index interval [2, 4) in the "uids" slice
-	// are not on disk. As common in maths, [ denotes a closed interval while ) denotes an open
-	// interval. That is, missing data is `uids[2:4]`.
-	assert.Equal(t, []rangeT{{start: 2, end: 4}}, ranges)
+func (m *mockDownloader) getAllMessageUUIDs(mbox *imap.MailboxStatus) ([]uid, error) {
+	args := m.Called(mbox)
+	return args.Get(0).([]uid), args.Error(1)
 }
 
-func TestDetermineMissingIDsMismatchesInRemoteData(t *testing.T) {
-	uids := []uid{
-		{Mbox: 1, Message: 1},
-		{Mbox: 0, Message: 5},
-		{Mbox: 0, Message: 6},
-	}
-
-	// UIDs are not consistent in uids slice.
-	_, err := determineMissingIDs([]oldmail{}, uids)
-	assert.Error(t, err)
-}
-
-func TestDetermineMissingIDsMismatches(t *testing.T) {
-	oldmails := []oldmail{
-		{uidValidity: 1, uid: 1, timestamp: 0},
-	}
-	uids := []uid{
-		{Mbox: 0, Message: 1},
-	}
-
-	// UIDs are not consistent between uid and oldmails slices.
-	_, err := determineMissingIDs(oldmails, uids)
-	assert.Error(t, err)
-}
-
-func TestDetermineMissingIDsSomeMissingNonconsecutiveRanges(t *testing.T) {
-	oldmails := []oldmail{
-		{uidValidity: 0, uid: 1, timestamp: 0},
-		{uidValidity: 0, uid: 3, timestamp: 0},
-		{uidValidity: 0, uid: 4, timestamp: 0},
-		{uidValidity: 0, uid: 6, timestamp: 0},
-	}
-	uids := []uid{
-		{Mbox: 0, Message: 1},
-		{Mbox: 0, Message: 2},
-		{Mbox: 0, Message: 3},
-		{Mbox: 0, Message: 4},
-		{Mbox: 0, Message: 5},
-		{Mbox: 0, Message: 6},
-	}
-
-	ranges, err := determineMissingIDs(oldmails, uids)
-
-	assert.NoError(t, err)
-	assert.Equal(t, []rangeT{{start: 2, end: 3}, {start: 5, end: 6}}, ranges)
-}
-
-// This re-uses the mockEmail struct from the email tests.
-func buildFakeEmail(hasNoData bool) *mockEmail {
-	someTime := time.Now()
-	msg := mockEmail{}
-	if hasNoData {
-		msg.On("Format").Return(
-			// This email misses all fields, which causes errors.
-			[]interface{}{},
-		)
-	} else {
-		msg.On("Format").Return(
-			// This email has all the fields we require.
-			[]interface{}{
-				imap.RawString("uid header"),
-				uint32(1),
-				imap.RawString("time header"),
-				someTime,
-				"rfc822 header",
-				"actual content",
-			},
-		)
-	}
-	return &msg
-}
-
-func TestStreamingDeliverySuccessDespiteOneError(t *testing.T) {
-	// Set up output directory and input channels.
-	tmpdir := setUpEmptyMaildir(t, "folder", "oldmail")
-	maildir := filepath.Join(tmpdir, "folder")
-	resultDir := filepath.Join(maildir, "new")
-
-	// Set up goroutine providing input and remember mocks to later assert on them.
-	mocks := []*mockEmail{}
-	msgChan := make(chan emailOps)
+func (m *mockDownloader) streamingOldmailWriteout(
+	deliveredChan <-chan oldmail, oldmailPath string, wg, startWg *sync.WaitGroup,
+) (*int, error) {
+	args := m.Called(deliveredChan, oldmailPath, wg, startWg)
+	wg.Add(1)
 	go func() {
-		for i := 0; i < 10; i++ {
-			// Nine of these emails will provide all the data we need to store them. One, the one at
-			// i==5, will not have any data. We use this to ensure we can continue processing emails
-			// even though one has problems.
-			msg := buildFakeEmail(i == 5)
-			msgChan <- msg
-			mocks = append(mocks, msg)
+		startWg.Wait()
+		idx := 0
+		for om := range deliveredChan {
+			assert.Equal(m.t, om, m.delivered[idx])
+			idx++
 		}
-		close(msgChan)
+		wg.Done()
 	}()
-
-	var wg, stwg sync.WaitGroup
-	// Delay actual operations until the entire pipeline has been set up.
-	stwg.Add(1)
-
-	uidvalidity := 0
-
-	oldmailChan, errCountPtr := streamingDelivery(msgChan, maildir, uidvalidity, &wg, &stwg)
-	assert.Zero(t, *errCountPtr)
-
-	// Wait a while and check that nothing has happened yet.
-	time.Sleep(time.Millisecond * 100) // nolint: gomnd
-	content, err := ioutil.ReadDir(resultDir)
-	assert.NoError(t, err)
-	assert.Empty(t, content)
-	assert.Empty(t, mocks)
-
-	// Actually trigger operations and read from output channel.
-	stwg.Done()
-	oldmails := []oldmail{}
-	for om := range oldmailChan {
-		oldmails = append(oldmails, om)
-	}
-	wg.Wait()
-	assert.Equal(t, 1, *errCountPtr)
-	assert.Equal(t, 9, len(oldmails))
-
-	// Ensure that we did write as many emails to the directory as we put in, apart from the one
-	// that lacked data.
-	content, err = ioutil.ReadDir(resultDir)
-	assert.NoError(t, err)
-	assert.Equal(t, 9, len(content))
-	assert.Equal(t, 10, len(mocks))
-
-	// Ensure that each email had its Format method called.
-	for _, msg := range mocks {
-		msg.AssertExpectations(t)
-	}
+	return args.Get(0).(*int), args.Error(1)
 }
 
-func buildFakeImapMessage(t *testing.T, id uint32, content string) *imap.Message {
-	sectionName, err := imap.ParseBodySectionName(imap.FetchItem("RFC822"))
-	assert.NoError(t, err)
+func (m *mockDownloader) streamingRetrieval(
+	mbox *imap.MailboxStatus, missingIDRanges []rangeT, wg, startWg *sync.WaitGroup,
+) (<-chan emailOps, *int, error) {
+	args := m.Called(mbox, missingIDRanges, wg, startWg)
+	wg.Add(1)
+	go func() {
+		startWg.Wait()
+		for _, msg := range m.messages {
+			var converted emailOps = msg
+			m.messageChan <- converted
+		}
+		close(m.messageChan)
+		wg.Done()
+	}()
+	return args.Get(0).(chan emailOps), args.Get(1).(*int), args.Error(2)
+}
 
-	buf := bytes.NewBufferString(content)
-
-	return &imap.Message{
-		Uid: id,
-		Items: map[imap.FetchItem]interface{}{
-			"INTERNALDATE": nil,
-			"RFC822":       nil,
-			"UID":          nil,
-		},
-		Body: map[*imap.BodySectionName]imap.Literal{
-			sectionName: buf,
-		},
-	}
+func (m *mockDownloader) streamingDelivery(
+	messageChan <-chan emailOps, maildirPath string, uidvalidity int, wg, startWg *sync.WaitGroup,
+) (<-chan oldmail, *int) {
+	args := m.Called(messageChan, maildirPath, uidvalidity, wg, startWg)
+	wg.Add(1)
+	go func() {
+		startWg.Wait()
+		idx := 0
+		for msg := range messageChan {
+			assert.Equal(m.t, msg, m.messages[idx])
+			m.deliveredChan <- m.delivered[idx]
+			idx++
+		}
+		close(m.deliveredChan)
+		wg.Done()
+	}()
+	return args.Get(0).(chan oldmail), args.Get(1).(*int)
 }
 
 func TestDownloadMissingEmailsToFolderSuccess(t *testing.T) {
-	orgVerbosity := verbose
-	SetVerboseLogs(true)
-	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
+	tmpdir := t.TempDir()
+	maildirPath := maildirPathT{base: tmpdir, folder: "some-folder"}
+	folderPath := maildirPath.folderPath()
+	oldmailFileName := "some-oldmail-file"
+	oldmailPath := filepath.Join(tmpdir, oldmailFileName)
 
-	mockPath := setUpEmptyMaildir(t, "some-folder", "some-oldmail")
+	mbox := &imap.MailboxStatus{
+		Name:        "some-folder",
+		UidValidity: 42,
+		Messages:    3,
+	}
+	uids := []uid{
+		{Mbox: 42, Message: 1},
+		{Mbox: 42, Message: 2},
+		{Mbox: 42, Message: 3},
+	}
+	missingIDRanges := []rangeT{{start: 1, end: 4}}
 
-	boxes := []*imap.MailboxInfo{&imap.MailboxInfo{Name: "some-folder"}}
-	status := &imap.MailboxStatus{Name: "some-folder", UidValidity: 42, Messages: 3}
-	messages := []*imap.Message{
-		buildFakeImapMessage(t, 1, "some text"),
-		buildFakeImapMessage(t, 2, "some more text"),
-		buildFakeImapMessage(t, 3, "even more text"),
+	messages := []*mockEmail{
+		{uid: 1}, {uid: 2}, {uid: 3},
+	}
+	messageChan := make(chan emailOps)
+	var inMessageChan <-chan emailOps = messageChan
+	var fetchErrCount int
+
+	delivered := []oldmail{
+		{uidValidity: 42, uid: 1},
+		{uidValidity: 42, uid: 2},
+		{uidValidity: 42, uid: 3},
+	}
+	deliveredChan := make(chan oldmail)
+	var inDeliveredChan <-chan oldmail = deliveredChan
+	var deliverErrCount int
+
+	var oldmailErrCount int
+
+	m := &mockDownloader{
+		t:             t,
+		messages:      messages,
+		messageChan:   messageChan,
+		delivered:     delivered,
+		deliveredChan: deliveredChan,
 	}
 
-	seqSet := &imap.SeqSet{}
-	seqSet.AddRange(1, 3)
-	fetchRequestListUUIDs := []imap.FetchItem{imap.FetchUid, imap.FetchInternalDate}
-	fetchRequestDownload := []imap.FetchItem{
-		imap.FetchUid, imap.FetchInternalDate, imap.FetchRFC822,
-	}
+	m.On("selectFolder", "some-folder").Return(mbox, nil)
+	m.On("getAllMessageUUIDs", mbox).Return(uids, nil)
+	m.On("streamingRetrieval", mbox, missingIDRanges, mock.Anything, mock.Anything).
+		Return(messageChan, &fetchErrCount, nil)
+	m.On("streamingDelivery", inMessageChan, folderPath, 42, mock.Anything, mock.Anything).
+		Return(deliveredChan, &deliverErrCount)
+	m.On("streamingOldmailWriteout", inDeliveredChan, oldmailPath, mock.Anything, mock.Anything).
+		Return(&oldmailErrCount, nil)
 
-	mockClient := setUpMockClient(t, boxes, messages, nil)
-	mockClient.On("Select", "some-folder", true).Return(status, nil)
-	mockClient.On("Fetch", seqSet, fetchRequestListUUIDs, mock.Anything).Return(nil)
-	mockClient.On("Fetch", seqSet, fetchRequestDownload, mock.Anything).Return(nil)
-
-	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
-
-	err := downloadMissingEmailsToFolder(mockClient, maildirPath, "some-oldmail")
+	err := downloadMissingEmailsToFolder(m, maildirPath, oldmailFileName)
 
 	assert.NoError(t, err)
-
-	// Check whether emails have actually been downloaded and whether hte oldmail file has been
-	// updated.
-	oldmailContent, err := ioutil.ReadFile(filepath.Join(mockPath, "some-oldmail")) // nolint: gosec
-	assert.NoError(t, err)
-	downloadedMessages, err := ioutil.ReadDir(filepath.Join(mockPath, "some-folder", "new"))
-	assert.NoError(t, err)
-	// Oldmail file contains three lines.
-	assert.Equal(t, 3, bytes.Count(oldmailContent, []byte("\n")))
-	// New directory contains three files.
-	assert.Equal(t, 3, len(downloadedMessages))
-}
-
-func TestDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
-	orgVerbosity := verbose
-	SetVerboseLogs(true)
-	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
-
-	mockPath := setUpEmptyMaildir(t, "some-folder", "some-oldmail")
-
-	boxes := []*imap.MailboxInfo{&imap.MailboxInfo{Name: "some-folder"}}
-	status := &imap.MailboxStatus{Name: "some-folder", UidValidity: 42, Messages: 0}
-	// No emails, thus nothing to be downloaded.
-	messages := []*imap.Message{}
-
-	mockClient := setUpMockClient(t, boxes, messages, nil)
-	mockClient.On("Select", "some-folder", true).Return(status, fmt.Errorf("some error"))
-
-	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
-
-	err := downloadMissingEmailsToFolder(mockClient, maildirPath, "some-oldmail")
-
-	assert.Error(t, err)
-	assert.Equal(t, "some error", err.Error())
-}
-
-func TestDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
-	orgVerbosity := verbose
-	SetVerboseLogs(true)
-	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
-
-	mockPath := setUpEmptyMaildir(t, "some-folder", "some-oldmail")
-
-	boxes := []*imap.MailboxInfo{&imap.MailboxInfo{Name: "some-folder"}}
-	status := &imap.MailboxStatus{Name: "some-folder", UidValidity: 42, Messages: 3}
-	messages := []*imap.Message{
-		buildFakeImapMessage(t, 1, "some text"),
-		buildFakeImapMessage(t, 2, "some more text"),
-		// One of the messages does not contain the information we need, which will cause an error
-		// in the streaming email delivery that will be logged.
-		&imap.Message{},
-	}
-
-	seqSet := &imap.SeqSet{}
-	seqSet.AddRange(1, 3)
-	fetchRequestListUUIDs := []imap.FetchItem{imap.FetchUid, imap.FetchInternalDate}
-	fetchRequestDownload := []imap.FetchItem{
-		imap.FetchUid, imap.FetchInternalDate, imap.FetchRFC822,
-	}
-
-	mockClient := setUpMockClient(t, boxes, messages, nil)
-	mockClient.On("Select", "some-folder", true).Return(status, nil)
-	mockClient.On("Fetch", seqSet, fetchRequestListUUIDs, mock.Anything).Return(nil)
-
-	// Cause an error when retrieving emails because one email cannot be downloaded. Every
-	// successive download succeeds.
-	mockClient.On("Fetch", seqSet, fetchRequestDownload, mock.Anything).
-		Once().Return(fmt.Errorf("download error"))
-
-	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
-
-	err := downloadMissingEmailsToFolder(mockClient, maildirPath, "some-oldmail")
-
-	assert.Error(t, err)
-	assert.Equal(
-		t, "there were 1/1/0 errors while: retrieving/delivering/remembering mail", err.Error(),
-	)
-
-	// Check whether we could still download all successfully that were delivered and whether that
-	// email's information has been added to the oldmail file.
-	oldmailContent, err := ioutil.ReadFile(filepath.Join(mockPath, "some-oldmail")) // nolint: gosec
-	assert.NoError(t, err)
-	downloadedMessages, err := ioutil.ReadDir(filepath.Join(mockPath, "some-folder", "new"))
-	assert.NoError(t, err)
-	// Oldmail file contains two lines.
-	assert.Equal(t, 2, bytes.Count(oldmailContent, []byte("\n")))
-	// New directory contains two files.
-	assert.Equal(t, 2, len(downloadedMessages))
+	m.AssertExpectations(t)
 }

--- a/core/email_test.go
+++ b/core/email_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 type mockEmail struct {
+	uid int
 	mock.Mock
 }
 

--- a/core/ids.go
+++ b/core/ids.go
@@ -1,0 +1,82 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import "fmt"
+
+// Determine the indices of emails that have not yet been downloaded. The download process
+// indentifies emails by their indices and not by their UIDs. Thus, we need to take the server-side
+// information as is and not sort it in any way.
+// This means there can be a race condition where go-imapgrab retrieves data about emails, then some
+// emails are removed remotely, and them go-imapgrab downloads emails. This would result in
+// doenloading emails that are already on disk. This race condition cannot be avoided due to the way
+// IMAP servers work (if it can, please tell me :) ).
+func determineMissingIDs(oldmails []oldmail, uids []uid) (ranges []rangeT, err error) {
+	ranges = []rangeT{}
+	// Check special cases such as an empty mailbox or uidvalidities that do not agree.
+	if len(uids) == 0 {
+		return []rangeT{}, nil
+	}
+	uidvalidity := uids[0].Mbox
+	for _, msg := range uids {
+		if msg.Mbox != uidvalidity {
+			err = fmt.Errorf("inconsistent UID validity on retrieved data")
+			return
+		}
+	}
+	for _, msg := range oldmails {
+		if msg.uidValidity != uidvalidity {
+			err = fmt.Errorf("inconsistent UID validity on stored data")
+			return
+		}
+	}
+
+	// Add the UIDs of the oldmail data (the data stored on disk) to a map to simplify determining
+	// whether we've already downloaded some message.
+	oldmailUIDs := make(map[int]struct{}, len(oldmails))
+	for _, msg := range oldmails {
+		oldmailUIDs[msg.uid] = struct{}{}
+	}
+
+	// Determine which UIDs are missing on disk. The resulting structure will already be sorted.
+	missingIDs := []int{}
+	for msgIdx, msg := range uids {
+		if _, found := oldmailUIDs[msg.Message]; !found {
+			missingIDs = append(missingIDs, msgIdx+1) // Emails are identified starting at 1.
+		}
+	}
+	if len(missingIDs) == 0 {
+		// All's well, everything is already on disk.
+		return
+	}
+
+	// Extract consecutive ranges of UIDs from the missing UIDs, which speeds up downloading. That
+	// way, we avoid retrieving messages one at a time.
+	start := missingIDs[0]
+	last := start
+	for _, mis := range missingIDs {
+		if mis-last > 1 {
+			ranges = append(ranges, rangeT{start: start, end: last + 1})
+			start = mis
+		}
+		last = mis
+	}
+	ranges = append(ranges, rangeT{start: start, end: last + 1})
+
+	return ranges, nil
+}

--- a/core/ids_test.go
+++ b/core/ids_test.go
@@ -1,0 +1,132 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineMissingIDsEmptyData(t *testing.T) {
+	oldmails := []oldmail{}
+	uids := []uid{}
+
+	ranges, err := determineMissingIDs(oldmails, uids)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []rangeT{}, ranges)
+}
+
+func TestDetermineMissingIDsEverythingDownloaded(t *testing.T) {
+	// The fields uidValidity and Mbox mean the same thing. The fields uid and Message also mean the
+	// same thing. The remote server identifies messages by their position in uids instead of their
+	// actual unique identifiers. Thus, it is important that the uids slice is not rearranged in any
+	// way.
+	oldmails := []oldmail{
+		// Note that UIDs start at 1 according to the return values of IMAP servers.
+		{uidValidity: 0, uid: 1, timestamp: 0},
+		{uidValidity: 0, uid: 2, timestamp: 0},
+		{uidValidity: 0, uid: 3, timestamp: 0},
+	}
+	uids := []uid{
+		{Mbox: 0, Message: 1},
+		{Mbox: 0, Message: 3}, // 3 and 2 swapped deliberately.
+		{Mbox: 0, Message: 2},
+	}
+	orgUIDs := make([]uid, len(uids))
+	_ = copy(orgUIDs, uids)
+
+	ranges, err := determineMissingIDs(oldmails, uids)
+
+	assert.NoError(t, err)
+	assert.Equal(t, orgUIDs, uids)
+	assert.Equal(t, []rangeT{}, ranges)
+}
+
+func TestDetermineMissingIDsSomeMissing(t *testing.T) {
+	oldmails := []oldmail{
+		{uidValidity: 0, uid: 1, timestamp: 0},
+		{uidValidity: 0, uid: 2, timestamp: 0},
+		{uidValidity: 0, uid: 3, timestamp: 0},
+		{uidValidity: 0, uid: 4, timestamp: 0},
+	}
+	uids := []uid{
+		{Mbox: 0, Message: 1},
+		{Mbox: 0, Message: 5},
+		{Mbox: 0, Message: 6},
+	}
+	orgUIDs := make([]uid, len(uids))
+	_ = copy(orgUIDs, uids)
+
+	ranges, err := determineMissingIDs(oldmails, uids)
+
+	assert.NoError(t, err)
+	assert.Equal(t, orgUIDs, uids)
+	// This means that the emails that are located in the index interval [2, 4) in the "uids" slice
+	// are not on disk. As common in maths, [ denotes a closed interval while ) denotes an open
+	// interval. That is, missing data is `uids[2:4]`.
+	assert.Equal(t, []rangeT{{start: 2, end: 4}}, ranges)
+}
+
+func TestDetermineMissingIDsMismatchesInRemoteData(t *testing.T) {
+	uids := []uid{
+		{Mbox: 1, Message: 1},
+		{Mbox: 0, Message: 5},
+		{Mbox: 0, Message: 6},
+	}
+
+	// UIDs are not consistent in uids slice.
+	_, err := determineMissingIDs([]oldmail{}, uids)
+	assert.Error(t, err)
+}
+
+func TestDetermineMissingIDsMismatches(t *testing.T) {
+	oldmails := []oldmail{
+		{uidValidity: 1, uid: 1, timestamp: 0},
+	}
+	uids := []uid{
+		{Mbox: 0, Message: 1},
+	}
+
+	// UIDs are not consistent between uid and oldmails slices.
+	_, err := determineMissingIDs(oldmails, uids)
+	assert.Error(t, err)
+}
+
+func TestDetermineMissingIDsSomeMissingNonconsecutiveRanges(t *testing.T) {
+	oldmails := []oldmail{
+		{uidValidity: 0, uid: 1, timestamp: 0},
+		{uidValidity: 0, uid: 3, timestamp: 0},
+		{uidValidity: 0, uid: 4, timestamp: 0},
+		{uidValidity: 0, uid: 6, timestamp: 0},
+	}
+	uids := []uid{
+		{Mbox: 0, Message: 1},
+		{Mbox: 0, Message: 2},
+		{Mbox: 0, Message: 3},
+		{Mbox: 0, Message: 4},
+		{Mbox: 0, Message: 5},
+		{Mbox: 0, Message: 6},
+	}
+
+	ranges, err := determineMissingIDs(oldmails, uids)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []rangeT{{start: 2, end: 3}, {start: 5, end: 6}}, ranges)
+}

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -98,7 +98,7 @@ func selectFolder(imapClient imapOps, folder string) (*imap.MailboxStatus, error
 // converted to count from the last message. That is, -1 refers to the most recent message while 1
 // refers to the second oldest email.
 func streamingRetrieval(
-	mbox *imap.MailboxStatus, imapClient imapOps, indices []rangeT, wg, stwg *sync.WaitGroup,
+	mbox *imap.MailboxStatus, imapClient imapOps, indices []rangeT, wg, startWg *sync.WaitGroup,
 ) (returnedChan <-chan emailOps, errCountPtr *int, err error) {
 	// Make sure there are enough messages in this mailbox and we are not requesting a non-positive
 	// index.
@@ -119,7 +119,7 @@ func streamingRetrieval(
 	orgMessageChan := make(chan *imap.Message, messageRetrievalBuffer)
 	go func() {
 		// Do not start before the entire pipeline has been set up.
-		stwg.Wait()
+		startWg.Wait()
 		err := imapClient.Fetch(
 			seqset,
 			[]imap.FetchItem{imap.FetchUid, imap.FetchInternalDate, imap.FetchRFC822},

--- a/core/integration_test.go
+++ b/core/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -56,6 +57,10 @@ func buildFakeDownloader(imapOps imapOps) *downloader {
 }
 
 func TestIntegrationDownloadMissingEmailsToFolderSuccess(t *testing.T) {
+	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); found && val == "0" {
+		t.Skip("integration tests disabled")
+	}
+
 	orgVerbosity := verbose
 	SetVerboseLogs(true)
 	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
@@ -103,6 +108,10 @@ func TestIntegrationDownloadMissingEmailsToFolderSuccess(t *testing.T) {
 }
 
 func TestIntegrationDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
+	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); found && val == "0" {
+		t.Skip("integration tests disabled")
+	}
+
 	orgVerbosity := verbose
 	SetVerboseLogs(true)
 	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
@@ -128,6 +137,10 @@ func TestIntegrationDownloadMissingEmailsToFolderPreparationError(t *testing.T) 
 }
 
 func TestIntegrationDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
+	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); found && val == "0" {
+		t.Skip("integration tests disabled")
+	}
+
 	orgVerbosity := verbose
 	SetVerboseLogs(true)
 	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })

--- a/core/integration_test.go
+++ b/core/integration_test.go
@@ -1,0 +1,184 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/emersion/go-imap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func buildFakeImapMessage(t *testing.T, id uint32, content string) *imap.Message {
+	sectionName, err := imap.ParseBodySectionName(imap.FetchItem("RFC822"))
+	assert.NoError(t, err)
+
+	buf := bytes.NewBufferString(content)
+
+	return &imap.Message{
+		Uid: id,
+		Items: map[imap.FetchItem]interface{}{
+			"INTERNALDATE": nil,
+			"RFC822":       nil,
+			"UID":          nil,
+		},
+		Body: map[*imap.BodySectionName]imap.Literal{
+			sectionName: buf,
+		},
+	}
+}
+
+func buildFakeDownloader(imapOps imapOps) *downloader {
+	return &downloader{
+		imapOps:    imapOps,
+		deliverOps: deliverer{},
+	}
+}
+
+func TestDownloadMissingEmailsToFolderSuccess(t *testing.T) {
+	orgVerbosity := verbose
+	SetVerboseLogs(true)
+	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
+
+	mockPath := setUpEmptyMaildir(t, "some-folder", "some-oldmail")
+
+	boxes := []*imap.MailboxInfo{&imap.MailboxInfo{Name: "some-folder"}}
+	status := &imap.MailboxStatus{Name: "some-folder", UidValidity: 42, Messages: 3}
+	messages := []*imap.Message{
+		buildFakeImapMessage(t, 1, "some text"),
+		buildFakeImapMessage(t, 2, "some more text"),
+		buildFakeImapMessage(t, 3, "even more text"),
+	}
+
+	seqSet := &imap.SeqSet{}
+	seqSet.AddRange(1, 3)
+	fetchRequestListUUIDs := []imap.FetchItem{imap.FetchUid, imap.FetchInternalDate}
+	fetchRequestDownload := []imap.FetchItem{
+		imap.FetchUid, imap.FetchInternalDate, imap.FetchRFC822,
+	}
+
+	mockClient := setUpMockClient(t, boxes, messages, nil)
+	mockClient.On("Select", "some-folder", true).Return(status, nil)
+	mockClient.On("Fetch", seqSet, fetchRequestListUUIDs, mock.Anything).Return(nil)
+	mockClient.On("Fetch", seqSet, fetchRequestDownload, mock.Anything).Return(nil)
+
+	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
+
+	downloader := buildFakeDownloader(mockClient)
+
+	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail")
+
+	assert.NoError(t, err)
+
+	// Check whether emails have actually been downloaded and whether hte oldmail file has been
+	// updated.
+	oldmailContent, err := ioutil.ReadFile(filepath.Join(mockPath, "some-oldmail")) // nolint: gosec
+	assert.NoError(t, err)
+	downloadedMessages, err := ioutil.ReadDir(filepath.Join(mockPath, "some-folder", "new"))
+	assert.NoError(t, err)
+	// Oldmail file contains three lines.
+	assert.Equal(t, 3, bytes.Count(oldmailContent, []byte("\n")))
+	// New directory contains three files.
+	assert.Equal(t, 3, len(downloadedMessages))
+}
+
+func TestDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
+	orgVerbosity := verbose
+	SetVerboseLogs(true)
+	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
+
+	mockPath := setUpEmptyMaildir(t, "some-folder", "some-oldmail")
+
+	boxes := []*imap.MailboxInfo{&imap.MailboxInfo{Name: "some-folder"}}
+	status := &imap.MailboxStatus{Name: "some-folder", UidValidity: 42, Messages: 0}
+	// No emails, thus nothing to be downloaded.
+	messages := []*imap.Message{}
+
+	mockClient := setUpMockClient(t, boxes, messages, nil)
+	mockClient.On("Select", "some-folder", true).Return(status, fmt.Errorf("some error"))
+
+	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
+
+	downloader := buildFakeDownloader(mockClient)
+
+	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail")
+
+	assert.Error(t, err)
+	assert.Equal(t, "some error", err.Error())
+}
+
+func TestDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
+	orgVerbosity := verbose
+	SetVerboseLogs(true)
+	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
+
+	mockPath := setUpEmptyMaildir(t, "some-folder", "some-oldmail")
+
+	boxes := []*imap.MailboxInfo{&imap.MailboxInfo{Name: "some-folder"}}
+	status := &imap.MailboxStatus{Name: "some-folder", UidValidity: 42, Messages: 3}
+	messages := []*imap.Message{
+		buildFakeImapMessage(t, 1, "some text"),
+		buildFakeImapMessage(t, 2, "some more text"),
+		// One of the messages does not contain the information we need, which will cause an error
+		// in the streaming email delivery that will be logged.
+		&imap.Message{},
+	}
+
+	seqSet := &imap.SeqSet{}
+	seqSet.AddRange(1, 3)
+	fetchRequestListUUIDs := []imap.FetchItem{imap.FetchUid, imap.FetchInternalDate}
+	fetchRequestDownload := []imap.FetchItem{
+		imap.FetchUid, imap.FetchInternalDate, imap.FetchRFC822,
+	}
+
+	mockClient := setUpMockClient(t, boxes, messages, nil)
+	mockClient.On("Select", "some-folder", true).Return(status, nil)
+	mockClient.On("Fetch", seqSet, fetchRequestListUUIDs, mock.Anything).Return(nil)
+
+	// Cause an error when retrieving emails because one email cannot be downloaded. Every
+	// successive download succeeds.
+	mockClient.On("Fetch", seqSet, fetchRequestDownload, mock.Anything).
+		Once().Return(fmt.Errorf("download error"))
+
+	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
+
+	downloader := buildFakeDownloader(mockClient)
+
+	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail")
+
+	assert.Error(t, err)
+	assert.Equal(
+		t, "there were 1/1/0 errors while: retrieving/delivering/remembering mail", err.Error(),
+	)
+
+	// Check whether we could still download all successfully that were delivered and whether that
+	// email's information has been added to the oldmail file.
+	oldmailContent, err := ioutil.ReadFile(filepath.Join(mockPath, "some-oldmail")) // nolint: gosec
+	assert.NoError(t, err)
+	downloadedMessages, err := ioutil.ReadDir(filepath.Join(mockPath, "some-folder", "new"))
+	assert.NoError(t, err)
+	// Oldmail file contains two lines.
+	assert.Equal(t, 2, bytes.Count(oldmailContent, []byte("\n")))
+	// New directory contains two files.
+	assert.Equal(t, 2, len(downloadedMessages))
+}

--- a/core/integration_test.go
+++ b/core/integration_test.go
@@ -57,7 +57,7 @@ func buildFakeDownloader(imapOps imapOps) *downloader {
 }
 
 func TestIntegrationDownloadMissingEmailsToFolderSuccess(t *testing.T) {
-	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); found && val == "0" {
+	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); !found || val != "0" {
 		t.Skip("integration tests disabled")
 	}
 
@@ -108,7 +108,7 @@ func TestIntegrationDownloadMissingEmailsToFolderSuccess(t *testing.T) {
 }
 
 func TestIntegrationDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
-	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); found && val == "0" {
+	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); !found || val != "0" {
 		t.Skip("integration tests disabled")
 	}
 
@@ -137,7 +137,7 @@ func TestIntegrationDownloadMissingEmailsToFolderPreparationError(t *testing.T) 
 }
 
 func TestIntegrationDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
-	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); found && val == "0" {
+	if val, found := os.LookupEnv("SKIP_INTEGRATION_TESTS"); !found || val != "0" {
 		t.Skip("integration tests disabled")
 	}
 

--- a/core/integration_test.go
+++ b/core/integration_test.go
@@ -55,7 +55,7 @@ func buildFakeDownloader(imapOps imapOps) *downloader {
 	}
 }
 
-func TestDownloadMissingEmailsToFolderSuccess(t *testing.T) {
+func TestIntegrationDownloadMissingEmailsToFolderSuccess(t *testing.T) {
 	orgVerbosity := verbose
 	SetVerboseLogs(true)
 	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
@@ -102,7 +102,7 @@ func TestDownloadMissingEmailsToFolderSuccess(t *testing.T) {
 	assert.Equal(t, 3, len(downloadedMessages))
 }
 
-func TestDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
+func TestIntegrationDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
 	orgVerbosity := verbose
 	SetVerboseLogs(true)
 	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })
@@ -127,7 +127,7 @@ func TestDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
 	assert.Equal(t, "some error", err.Error())
 }
 
-func TestDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
+func TestIntegrationDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
 	orgVerbosity := verbose
 	SetVerboseLogs(true)
 	t.Cleanup(func() { SetVerboseLogs(orgVerbosity) })


### PR DESCRIPTION
This PR improves code abstraction by introducing some more interfaces. Tests
that used to be integration tests have been converted into unit tests where it
makes sense. Integration tests are no longer run by default but can be run
manually with a new make target. This PR is a prerequisite for adding more
features because it makes the code much easier to handle.
