### PR TITLE
feature/graceful interrupt on ctrl c

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -12,7 +12,6 @@ lint:
 	golangci-lint run .
 
 full-test:
-	touch go.mod
 	SKIP_INTEGRATION_TESTS=0 $(MAKE) .test.log
 
 test:

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -34,8 +34,8 @@ func (m *mockImapgrabber) authenticateClient(cfg IMAPConfig) error {
 	return args.Error(0)
 }
 
-func (m *mockImapgrabber) logout() error {
-	args := m.Called()
+func (m *mockImapgrabber) logout(doTerminate bool) error {
+	args := m.Called(doTerminate)
 	return args.Error(0)
 }
 
@@ -95,7 +95,20 @@ func TestImapgrabberLogout(t *testing.T) {
 	m.On("Logout").Return(fmt.Errorf("some error"))
 	ig.imapOps = m
 
-	err := ig.logout()
+	err := ig.logout(false)
+
+	assert.Error(t, err)
+}
+
+func TestImapgrabberTerminate(t *testing.T) {
+	ig, ok := NewImapgrabOps().(*Imapgrabber)
+	assert.True(t, ok)
+
+	m := setUpMockClient(t, nil, nil, nil)
+	m.On("Terminate").Return(fmt.Errorf("some error"))
+	ig.imapOps = m
+
+	err := ig.logout(true)
 
 	assert.Error(t, err)
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -125,7 +125,7 @@ func TestGetAllFolders(t *testing.T) {
 	mock := &mockImapgrabber{}
 	mock.On("authenticateClient", cfg).Return(nil)
 	mock.On("getFolderList").Return(folders, nil)
-	mock.On("logout").Return(fmt.Errorf("some error"))
+	mock.On("logout", false).Return(fmt.Errorf("some error"))
 
 	actualFolders, err := GetAllFolders(cfg, mock)
 
@@ -150,7 +150,7 @@ func TestDownloadFolder(t *testing.T) {
 	mock := &mockImapgrabber{}
 	mock.On("authenticateClient", cfg).Return(nil)
 	mock.On("getFolderList").Return(folders, nil)
-	mock.On("logout").Return(fmt.Errorf("some error"))
+	mock.On("logout", false).Return(fmt.Errorf("some error"))
 	mock.On("downloadMissingEmailsToFolder", maildirPathF1, oldmailF1).Return(nil)
 
 	err := DownloadFolder(cfg, folders, maildir, mock)
@@ -177,7 +177,7 @@ func TestDownloadFolderDownloadErr(t *testing.T) {
 	mock := &mockImapgrabber{}
 	mock.On("authenticateClient", cfg).Return(nil)
 	mock.On("getFolderList").Return(folders, nil)
-	mock.On("logout").Return(fmt.Errorf("some error"))
+	mock.On("logout", true).Return(fmt.Errorf("some error"))
 	mock.On("downloadMissingEmailsToFolder", maildirPathF1, oldmailF1).Return(nil)
 	mock.On("downloadMissingEmailsToFolder", maildirPathF2, oldmailF2).
 		Return(fmt.Errorf("download error"))

--- a/core/download.go
+++ b/core/download.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/emersion/go-imap"
@@ -34,7 +35,7 @@ type downloadOps interface {
 	getAllMessageUUIDs(*imap.MailboxStatus) ([]uid, error)
 	streamingOldmailWriteout(<-chan oldmail, string, *sync.WaitGroup, *sync.WaitGroup) (*int, error)
 	streamingRetrieval(
-		*imap.MailboxStatus, []rangeT, *sync.WaitGroup, *sync.WaitGroup,
+		*imap.MailboxStatus, []rangeT, *sync.WaitGroup, *sync.WaitGroup, <-chan os.Signal,
 	) (<-chan emailOps, *int, error)
 	streamingDelivery(
 		<-chan emailOps, string, int, *sync.WaitGroup, *sync.WaitGroup,
@@ -61,9 +62,12 @@ func (d downloader) streamingOldmailWriteout(
 }
 
 func (d downloader) streamingRetrieval(
-	mbox *imap.MailboxStatus, missingIDRanges []rangeT, wg, startWg *sync.WaitGroup,
+	mbox *imap.MailboxStatus,
+	missingIDRanges []rangeT,
+	wg, startWg *sync.WaitGroup,
+	interruptChan <-chan os.Signal,
 ) (<-chan emailOps, *int, error) {
-	return streamingRetrieval(mbox, d.imapOps, missingIDRanges, wg, startWg)
+	return streamingRetrieval(mbox, d.imapOps, missingIDRanges, wg, startWg, interruptChan)
 }
 
 func (d downloader) streamingDelivery(
@@ -73,7 +77,7 @@ func (d downloader) streamingDelivery(
 }
 
 func downloadMissingEmailsToFolder(
-	ops downloadOps, maildirPath maildirPathT, oldmailName string,
+	ops downloadOps, maildirPath maildirPathT, oldmailName string, sig interruptOps,
 ) error {
 	oldmails, oldmailPath, err := initMaildir(oldmailName, maildirPath)
 	var mbox *imap.MailboxStatus
@@ -100,10 +104,10 @@ func downloadMissingEmailsToFolder(
 
 	var wg, startWg sync.WaitGroup
 	startWg.Add(1) // startWg is used to defer operations until the pipeline is set up.
-
+	defer sig.register()()
 	// Retrieve email information. This does not download the emails themselves yet.
 	messageChan, fetchErrCount, err := ops.streamingRetrieval(
-		mbox, missingIDRanges, &wg, &startWg,
+		mbox, missingIDRanges, &wg, &startWg, sig.interruptChan(),
 	)
 	var deliveredChan <-chan oldmail
 	var deliverErrCount, oldmailErrCount *int

--- a/core/download_test.go
+++ b/core/download_test.go
@@ -141,19 +141,20 @@ func TestDownloadMissingEmailsToFolderSuccess(t *testing.T) {
 		deliveredChan: deliveredChan,
 	}
 
+	interrupt := make(interruptT)
+	mi := &mockInterrupter{}
+	mi.On("register").Return(mi.deregister)
+	mi.On("deregister").Return()
+	mi.On("interrupt").Return(interrupt)
+
 	m.On("selectFolder", "some-folder").Return(mbox, nil)
 	m.On("getAllMessageUUIDs", mbox).Return(uids, nil)
-	m.On("streamingRetrieval", mbox, missingIDRanges, mock.Anything, mock.Anything).
+	m.On("streamingRetrieval", mbox, missingIDRanges, mock.Anything, mock.Anything, interrupt).
 		Return(messageChan, &fetchErrCount, nil)
 	m.On("streamingDelivery", inMessageChan, folderPath, 42, mock.Anything, mock.Anything).
 		Return(deliveredChan, &deliverErrCount)
 	m.On("streamingOldmailWriteout", inDeliveredChan, oldmailPath, mock.Anything, mock.Anything).
 		Return(&oldmailErrCount, nil)
-
-	mi := &mockInterrupter{}
-	mi.On("reguister").Return(mi.deregister)
-	mi.On("dereguister").Return()
-	mi.On("signal").Return()
 
 	err := downloadMissingEmailsToFolder(m, maildirPath, oldmailFileName, mi)
 
@@ -178,9 +179,9 @@ func TestDownloadMissingEmailsToFolderPreparationError(t *testing.T) {
 	m.On("selectFolder", "some-folder").Return(mbox, fmt.Errorf("some error"))
 
 	mi := &mockInterrupter{}
-	mi.On("reguister").Return(mi.deregister)
-	mi.On("dereguister").Return()
-	mi.On("signal").Return()
+	mi.On("register").Return(mi.deregister)
+	mi.On("deregister").Return()
+	mi.On("interrupt").Return(make(interruptT))
 
 	err := downloadMissingEmailsToFolder(m, maildirPath, oldmailFileName, mi)
 
@@ -208,9 +209,9 @@ func TestDownloadMissingEmailsToFolderPreparationNoNewEmails(t *testing.T) {
 	m.On("getAllMessageUUIDs", mbox).Return(uids, nil)
 
 	mi := &mockInterrupter{}
-	mi.On("reguister").Return(mi.deregister)
-	mi.On("dereguister").Return()
-	mi.On("signal").Return()
+	mi.On("register").Return(mi.deregister)
+	mi.On("deregister").Return()
+	mi.On("interrupt").Return(make(interruptT))
 
 	err := downloadMissingEmailsToFolder(m, maildirPath, oldmailFileName, mi)
 
@@ -228,9 +229,7 @@ func TestDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
 	oldmailPath := filepath.Join(tmpdir, oldmailFileName)
 
 	mbox := &imap.MailboxStatus{
-		Name:        "some-folder",
-		UidValidity: 42,
-		Messages:    3,
+		Name: "some-folder", UidValidity: 42, Messages: 3,
 	}
 	uids := []uid{
 		{Mbox: 42, Message: 1}, {Mbox: 42, Message: 2}, {Mbox: 42, Message: 3},
@@ -258,19 +257,20 @@ func TestDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
 		deliveredChan: deliveredChan,
 	}
 
+	interrupt := make(interruptT)
+	mi := &mockInterrupter{}
+	mi.On("register").Return(mi.deregister)
+	mi.On("deregister").Return()
+	mi.On("interrupt").Return(interrupt)
+
 	m.On("selectFolder", "some-folder").Return(mbox, nil)
 	m.On("getAllMessageUUIDs", mbox).Return(uids, nil)
-	m.On("streamingRetrieval", mbox, missingIDRanges, mock.Anything, mock.Anything).
+	m.On("streamingRetrieval", mbox, missingIDRanges, mock.Anything, mock.Anything, interrupt).
 		Return(messageChan, &fetchErrCount, nil)
 	m.On("streamingDelivery", inMessageChan, folderPath, 42, mock.Anything, mock.Anything).
 		Return(deliveredChan, &deliverErrCount)
 	m.On("streamingOldmailWriteout", inDeliveredChan, oldmailPath, mock.Anything, mock.Anything).
 		Return(&oldmailErrCount, nil)
-
-	mi := &mockInterrupter{}
-	mi.On("reguister").Return(mi.deregister)
-	mi.On("dereguister").Return()
-	mi.On("signal").Return()
 
 	err := downloadMissingEmailsToFolder(m, maildirPath, oldmailFileName, mi)
 

--- a/core/email.go
+++ b/core/email.go
@@ -104,10 +104,6 @@ func (e email) String() string {
 // Convert an imap.Message into its content according to rfc822. That content can then be stored in
 // a maildir as is.
 func rfc822FromEmail(msg emailOps, uidvalidity int) (text string, oldmailInfo oldmail, err error) {
-	// We cannot guarantee that msg contains any useful data, but the Format routine does not check
-	// whether there is any data. Instead, it will simply panic. There is no way for us to check
-	// what went wrong. Thus, we recover from the panic.
-	defer recoverFromPanic(logWarning, &err)
 	fields := msg.Format()
 	if len(fields) != rfc822ExpectedNumFields {
 		return "", oldmail{}, fmt.Errorf("cannot extract required rfc822 fields from email")

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -171,9 +171,13 @@ func streamingRetrieval(
 				logWarning("caught keyboard interrupt, closing connection")
 				errCount++
 			case msg := <-orgMessageChan:
-				// Here, the compiler auto-generates the code to translate a `*imap.Message` into a
-				// `emailOps`.
-				translatedMessageChan <- msg
+				// Somehow, we sometimes receive nil values from the channel. We do not want to
+				// process those any further, which is why we filter them out here.
+				if msg != nil {
+					// Here, the compiler auto-generates the code to translate a `*imap.Message`
+					// into a `emailOps`.
+					translatedMessageChan <- msg
+				}
 			}
 		}
 	}()

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -103,6 +103,7 @@ type atomicBool struct {
 // Obtain messages whose ids/indices lie in certain ranges. Negative indices are automatically
 // converted to count from the last message. That is, -1 refers to the most recent message while 1
 // refers to the second oldest email.
+//nolint:funlen
 func streamingRetrieval(
 	mbox *imap.MailboxStatus,
 	imapClient imapOps,
@@ -167,7 +168,7 @@ func streamingRetrieval(
 					wg.Done()
 				}
 				// Clean up and report.
-				logWarning("caught keyboard interupt, closing connection")
+				logWarning("caught keyboard interrupt, closing connection")
 				errCount++
 			case msg := <-orgMessageChan:
 				// Here, the compiler auto-generates the code to translate a `*imap.Message` into a

--- a/core/imap_client_test.go
+++ b/core/imap_client_test.go
@@ -41,11 +41,11 @@ func (mc *mockClient) Login(username string, password string) error {
 }
 
 func (mc *mockClient) List(ref string, name string, ch chan *imap.MailboxInfo) error {
+	defer close(ch)
 	args := mc.Called(ref, name, ch)
 	for _, box := range mc.mailboxes {
 		ch <- box
 	}
-	close(ch)
 	return args.Error(0)
 }
 
@@ -57,11 +57,11 @@ func (mc *mockClient) Select(name string, readOnly bool) (*imap.MailboxStatus, e
 func (mc *mockClient) Fetch(
 	seqset *imap.SeqSet, items []imap.FetchItem, ch chan *imap.Message,
 ) error {
+	defer close(ch)
 	args := mc.Called(seqset, items, ch)
 	for _, msg := range mc.messages {
 		ch <- msg
 	}
-	close(ch)
 	return args.Error(0)
 }
 

--- a/core/imap_client_test.go
+++ b/core/imap_client_test.go
@@ -70,6 +70,11 @@ func (mc *mockClient) Logout() error {
 	return args.Error(0)
 }
 
+func (mc *mockClient) Terminate() error {
+	args := mc.Called()
+	return args.Error(0)
+}
+
 func setUpMockClient(
 	t *testing.T, boxes []*imap.MailboxInfo, messages []*imap.Message, err error,
 ) *mockClient {
@@ -215,7 +220,7 @@ func TestStreamingRetrievalSuccess(t *testing.T) {
 	var wg, stwg sync.WaitGroup
 	stwg.Add(1)
 
-	emailChan, errPtr, err := streamingRetrieval(status, m, ranges, &wg, &stwg)
+	emailChan, errPtr, err := streamingRetrieval(status, m, ranges, &wg, &stwg, make(interruptT))
 
 	assert.NoError(t, err)
 	assert.Zero(t, *errPtr)
@@ -255,7 +260,7 @@ func TestStreamingRetrievalError(t *testing.T) {
 	var wg, stwg sync.WaitGroup
 	stwg.Add(1)
 
-	_, _, err := streamingRetrieval(status, m, ranges, &wg, &stwg)
+	_, _, err := streamingRetrieval(status, m, ranges, &wg, &stwg, make(interruptT))
 
 	assert.Error(t, err)
 }

--- a/core/integration_test.go
+++ b/core/integration_test.go
@@ -90,8 +90,9 @@ func TestIntegrationDownloadMissingEmailsToFolderSuccess(t *testing.T) {
 	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
 
 	downloader := buildFakeDownloader(mockClient)
+	interrupter := newInterruptOps(nil)
 
-	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail")
+	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail", interrupter)
 
 	assert.NoError(t, err)
 
@@ -129,8 +130,9 @@ func TestIntegrationDownloadMissingEmailsToFolderPreparationError(t *testing.T) 
 	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
 
 	downloader := buildFakeDownloader(mockClient)
+	interrupter := newInterruptOps(nil)
 
-	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail")
+	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail", interrupter)
 
 	assert.Error(t, err)
 	assert.Equal(t, "some error", err.Error())
@@ -176,8 +178,9 @@ func TestIntegrationDownloadMissingEmailsToFolderDownloadError(t *testing.T) {
 	maildirPath := maildirPathT{base: mockPath, folder: "some-folder"}
 
 	downloader := buildFakeDownloader(mockClient)
+	interrupter := newInterruptOps(nil)
 
-	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail")
+	err := downloadMissingEmailsToFolder(downloader, maildirPath, "some-oldmail", interrupter)
 
 	assert.Error(t, err)
 	assert.Equal(

--- a/core/interrupt.go
+++ b/core/interrupt.go
@@ -37,7 +37,7 @@ type interrupter struct {
 }
 
 func (i *interrupter) register() func() {
-	signalChan := make(chan os.Signal)
+	signalChan := make(chan os.Signal, len(i.signals))
 	signal.Notify(signalChan, i.signals...)
 	i.channel = signalChan
 	return i.deregister

--- a/core/interrupt.go
+++ b/core/interrupt.go
@@ -1,0 +1,72 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+type interruptOps interface {
+	register() func()
+	deregister()
+	interruptChan() <-chan os.Signal
+}
+
+type interrupter struct {
+	signals []os.Signal
+	channel chan os.Signal
+}
+
+func (i *interrupter) register() func() {
+	signalChan := make(chan os.Signal)
+	signal.Notify(signalChan, i.signals...)
+	i.channel = signalChan
+	return i.deregister
+}
+
+func (i *interrupter) deregister() {
+	signal.Stop(i.channel)
+	i.channel = nil
+}
+
+func (i *interrupter) interruptChan() <-chan os.Signal {
+	return i.channel
+}
+
+func newInterruptOps(signals []os.Signal) interruptOps {
+	return &interrupter{signals: signals}
+}
+
+func recoverFromPanic(fn func(string), outerErr *error) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+
+	var err error
+	var ok bool
+	if err, ok = recovered.(error); !ok {
+		err = fmt.Errorf("%v", recovered)
+	}
+	fn(err.Error())
+	if outerErr != nil && *outerErr == nil {
+		*outerErr = err
+	}
+}

--- a/core/interrupt.go
+++ b/core/interrupt.go
@@ -23,10 +23,12 @@ import (
 	"os/signal"
 )
 
+type interruptT <-chan os.Signal
+
 type interruptOps interface {
 	register() func()
 	deregister()
-	interruptChan() <-chan os.Signal
+	interrupt() interruptT
 }
 
 type interrupter struct {
@@ -46,7 +48,7 @@ func (i *interrupter) deregister() {
 	i.channel = nil
 }
 
-func (i *interrupter) interruptChan() <-chan os.Signal {
+func (i *interrupter) interrupt() interruptT {
 	return i.channel
 }
 

--- a/core/interrupt.go
+++ b/core/interrupt.go
@@ -18,7 +18,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package core
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 )
@@ -54,21 +53,4 @@ func (i *interrupter) interrupt() interruptT {
 
 func newInterruptOps(signals []os.Signal) interruptOps {
 	return &interrupter{signals: signals}
-}
-
-func recoverFromPanic(fn func(string), outerErr *error) {
-	recovered := recover()
-	if recovered == nil {
-		return
-	}
-
-	var err error
-	var ok bool
-	if err, ok = recovered.(error); !ok {
-		err = fmt.Errorf("%v", recovered)
-	}
-	fn(err.Error())
-	if outerErr != nil && *outerErr == nil {
-		*outerErr = err
-	}
 }

--- a/core/interrupt_test.go
+++ b/core/interrupt_test.go
@@ -1,0 +1,38 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package core
+
+import "github.com/stretchr/testify/mock"
+
+type mockInterrupter struct {
+	mock.Mock
+}
+
+func (i *mockInterrupter) register() func() {
+	args := i.Called()
+	return args.Get(0).(func())
+}
+
+func (i *mockInterrupter) deregister() {
+	_ = i.Called()
+}
+
+func (i *mockInterrupter) interrupt() interruptT {
+	args := i.Called()
+	return args.Get(0).(interruptT)
+}


### PR DESCRIPTION
This PR introduces a way to detect and gracefully exit after receiving a
keyboard interrupt. This is important so that we do not leave the file system in
an inconsistent state (i.e. email written to disk but oldmail data not written
to disk).

Closed #26.
