### PR TITLE
Safeguard against parallel execution via lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage_badge_report.out
 coverage.html
 go-imapgrab
 dist/
+.go-imapgrab.lock

--- a/cli/download.go
+++ b/cli/download.go
@@ -38,7 +38,12 @@ type downloadConfigT struct {
 }
 
 func getDownloadCmd(
-	rootConf *rootConfigT, keyring keyringOps, prodRun bool, ops coreOps,
+	rootConf *rootConfigT,
+	downloadConf *downloadConfigT,
+	keyring keyringOps,
+	prodRun bool,
+	ops coreOps,
+	lockFn lockFn,
 ) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download",
@@ -53,7 +58,7 @@ func getDownloadCmd(
 			}
 			lockfile := filepath.Join(downloadConf.path, lockfileName)
 			lockTimeout := time.Duration(downloadConf.timeoutSeconds) * time.Second
-			unlock, err := lock(lockfile, lockTimeout)
+			unlock, err := lockFn(lockfile, lockTimeout)
 			if err != nil {
 				return fmt.Errorf(
 					"cannot get lock on download folder, another process might be downloading: %s",
@@ -76,7 +81,7 @@ func getDownloadCmd(
 	return cmd
 }
 
-var downloadCmd = getDownloadCmd(&rootConf, defaultKeyring, true, &corer{})
+var downloadCmd = getDownloadCmd(&rootConf, &downloadConf, defaultKeyring, true, &corer{}, lock)
 
 func init() {
 	initDownloadFlags(downloadCmd)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,6 +6,7 @@ replace github.com/razziel89/go-imapgrab/core => ../core
 
 require (
 	github.com/razziel89/go-imapgrab/core v0.0.0-20230313202000-bc375372818b
+	github.com/rogpeppe/go-internal v1.10.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.7.1
 	github.com/zalando/go-keyring v0.2.2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -19,6 +19,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=

--- a/cli/lock.go
+++ b/cli/lock.go
@@ -1,0 +1,66 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+const (
+	lockfileName = ".go-imapgrab.lock"
+	dirPerms     = 0755
+)
+
+// Since channels can only pass on single types but no tuples, we create this type.
+type lockedT struct {
+	unlock func()
+	err    error
+}
+
+func doLock(lockfilePath string) lockedT {
+	unlock, err := lockedfile.MutexAt(lockfilePath).Lock()
+	return lockedT{
+		unlock: unlock,
+		err:    err,
+	}
+}
+
+func lock(lockfilePath string, timeout time.Duration) (func(), error) {
+	// Automatically create all elements of the path to the lockflie, if they do not exist.
+	err := os.MkdirAll(filepath.Dir(lockfilePath), dirPerms)
+	if err != nil {
+		return nil, err
+	}
+
+	resultChan := make(chan lockedT, 1)
+	go func() {
+		resultChan <- doLock(lockfilePath)
+	}()
+
+	select {
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("could not acquire lock on %s within %s", lockfilePath, timeout)
+	case result := <-resultChan:
+		return result.unlock, result.err
+	}
+}

--- a/cli/lock_test.go
+++ b/cli/lock_test.go
@@ -1,0 +1,106 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockAndReleaseSuccess(t *testing.T) {
+	tmpdir := t.TempDir()
+	lockfile := filepath.Join(tmpdir, "test.lock")
+
+	unlock, err := lock(lockfile, time.Millisecond)
+	assert.NoError(t, err)
+	unlock()
+}
+
+func TestLockCanBeReacquiredAfterRelease(t *testing.T) {
+	tmpdir := t.TempDir()
+	lockfile := filepath.Join(tmpdir, "test.lock")
+
+	unlock, err := lock(lockfile, time.Millisecond)
+	require.NoError(t, err)
+	unlock()
+
+	unlock, err = lock(lockfile, time.Millisecond)
+	assert.NoError(t, err)
+	unlock()
+}
+
+func TestLockCannotCreateParentDir(t *testing.T) {
+	tmpdir := t.TempDir()
+	file := filepath.Join(tmpdir, "not_a_dir")
+	// Create an empty file because we cannot create a file under it.
+	err := os.WriteFile(file, []byte{}, 0600)
+	require.NoError(t, err)
+	lockfile := filepath.Join(file, "test.lock")
+
+	_, err = lock(lockfile, time.Millisecond)
+	assert.ErrorContains(t, err, "not a directory")
+}
+
+func TestLockCannotBeAcquiredMultipleTimes(t *testing.T) {
+	tmpdir := t.TempDir()
+	lockfile := filepath.Join(tmpdir, "test.lock")
+	wg := sync.WaitGroup{}
+
+	var firstLockErr, secondLockErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		unlock, err := lock(lockfile, time.Millisecond)
+		firstLockErr = err
+		// Due to sleeping, the other goroutine in this test should have enough time to catch up and
+		// try to get the lock.
+		time.Sleep(50 * time.Millisecond)
+		if unlock != nil {
+			unlock()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		unlock, err := lock(lockfile, time.Millisecond)
+		secondLockErr = err
+		// Due to sleeping, the other goroutine in this test should have enough time to catch up and
+		// try to get the lock.
+		time.Sleep(50 * time.Millisecond)
+		if unlock != nil {
+			unlock()
+		}
+	}()
+
+	wg.Wait()
+	// Only one of the two goroutines could get the lock. If it's not the first, we simply swap
+	// errors to simplify the assertions.
+	if firstLockErr != nil && secondLockErr == nil {
+		firstLockErr, secondLockErr = secondLockErr, firstLockErr
+	}
+	assert.NoError(t, firstLockErr)
+	assert.ErrorContains(t, secondLockErr, "could not acquire lock")
+}


### PR DESCRIPTION
This PR adds functionality that uses lockfiles to prevent two invocations of
go-imapgrab to download to the same maildir at the same time. New tests have
been added and existing ones adjusted.

Fixes #25.
