### PR TITLE
feature/system tests

### DIFF
--- a/cli/download.go
+++ b/cli/download.go
@@ -50,11 +50,14 @@ func getDownloadCmd(
 		Short: "Download all not yet downloaded emails from a folder to a maildir.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			core.SetVerboseLogs(verbose)
+			// Allow insecure auth for local server for testing.
+			insecure := rootConf.server == "127.0.0.1"
 			cfg := core.IMAPConfig{
 				Server:   rootConf.server,
 				Port:     rootConf.port,
 				User:     rootConf.username,
 				Password: rootConf.password,
+				Insecure: insecure,
 			}
 			lockfile := filepath.Join(downloadConf.path, lockfileName)
 			lockTimeout := time.Duration(downloadConf.timeoutSeconds) * time.Second
@@ -84,14 +87,15 @@ func getDownloadCmd(
 var downloadCmd = getDownloadCmd(&rootConf, &downloadConf, defaultKeyring, true, &corer{}, lock)
 
 func init() {
-	initDownloadFlags(downloadCmd)
+	initDownloadFlags(downloadCmd, &downloadConf)
+	initRootFlags(downloadCmd, &rootConf)
 	rootCmd.AddCommand(downloadCmd)
 }
 
-func initDownloadFlags(downloadCmd *cobra.Command) {
-	pflags := downloadCmd.PersistentFlags()
+func initDownloadFlags(downloadCmd *cobra.Command, downloadConf *downloadConfigT) {
+	flags := downloadCmd.Flags()
 
-	pflags.StringSliceVarP(
+	flags.StringSliceVarP(
 		&downloadConf.folders,
 		"folder", "f", []string{},
 		"a folder spec specifying something to download (can be a folder name,\n"+
@@ -99,12 +103,12 @@ func initDownloadFlags(downloadCmd *cobra.Command) {
 			"flag multiple times for multiple specs, prepend a minus '-' to any\n"+
 			"spec to deselect instead, specs are interpreted in order)\n",
 	)
-	pflags.StringVar(&downloadConf.path, "path", "", "the local path to your maildir's parent dir")
-	pflags.IntVarP(
+	flags.StringVar(&downloadConf.path, "path", "", "the local path to your maildir's parent dir")
+	flags.IntVarP(
 		&downloadConf.threads, "threads", "t", 0,
 		"number of download threads to use, one per folder by default",
 	)
-	pflags.IntVar(
+	flags.IntVar(
 		&downloadConf.timeoutSeconds, "timeout", defaultTimeoutSeconds,
 		"time in seconds to wait for acquiring a lock on the download folder",
 	)

--- a/cli/download.go
+++ b/cli/download.go
@@ -51,7 +51,7 @@ func getDownloadCmd(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			core.SetVerboseLogs(verbose)
 			// Allow insecure auth for local server for testing.
-			insecure := rootConf.server == "127.0.0.1"
+			insecure := rootConf.server == localhost
 			cfg := core.IMAPConfig{
 				Server:   rootConf.server,
 				Port:     rootConf.port,

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,6 +5,7 @@ go 1.17
 replace github.com/razziel89/go-imapgrab/core => ../core
 
 require (
+	github.com/emersion/go-imap v1.2.1
 	github.com/razziel89/go-imapgrab/core v0.0.0-20230313202000-bc375372818b
 	github.com/rogpeppe/go-internal v1.10.0
 	github.com/spf13/cobra v1.7.0
@@ -17,8 +18,9 @@ require (
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emersion/go-imap v1.2.1 // indirect
+	github.com/emersion/go-message v0.15.0 // indirect
 	github.com/emersion/go-sasl v0.0.0-20220912192320-0145f2c60ead // indirect
+	github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -8,10 +8,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
 github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
+github.com/emersion/go-message v0.15.0 h1:urgKGqt2JAc9NFJcgncQcohHdiYb803YTH9OQwHBHIY=
 github.com/emersion/go-message v0.15.0/go.mod h1:wQUEfE+38+7EW8p8aZ96ptg6bAb1iwdgej19uXASlE4=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/emersion/go-sasl v0.0.0-20220912192320-0145f2c60ead h1:fI1Jck0vUrXT8bnphprS1EoVRe2Q5CKCX8iDlpqjQ/Y=
 github.com/emersion/go-sasl v0.0.0-20220912192320-0145f2c60ead/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594 h1:IbFBtwoTQyw0fIM5xv1HF+Y+3ZijDR839WMulgxCcUY=
 github.com/emersion/go-textwrapper v0.0.0-20200911093747-65d896831594/go.mod h1:aqO8z8wPrjkscevZJFVE1wXJrLpC5LtJG7fqLOsPb2U=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/cli/list.go
+++ b/cli/list.go
@@ -34,11 +34,14 @@ func getListCmd(
 		Short: "Print all folders in your inbox.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			core.SetVerboseLogs(verbose)
+			// Allow insecure auth for local server for testing.
+			insecure := rootConf.server == "127.0.0.1"
 			cfg := core.IMAPConfig{
 				Server:   rootConf.server,
 				Port:     rootConf.port,
 				User:     rootConf.username,
 				Password: rootConf.password,
+				Insecure: insecure,
 			}
 			folders, err := ops.getAllFolders(cfg)
 
@@ -61,5 +64,6 @@ func getListCmd(
 var listCmd = getListCmd(&rootConf, defaultKeyring, true, &corer{})
 
 func init() {
+	initRootFlags(listCmd, &rootConf)
 	rootCmd.AddCommand(listCmd)
 }

--- a/cli/list.go
+++ b/cli/list.go
@@ -35,7 +35,7 @@ func getListCmd(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			core.SetVerboseLogs(verbose)
 			// Allow insecure auth for local server for testing.
-			insecure := rootConf.server == "127.0.0.1"
+			insecure := rootConf.server == localhost
 			cfg := core.IMAPConfig{
 				Server:   rootConf.server,
 				Port:     rootConf.port,

--- a/cli/main.go
+++ b/cli/main.go
@@ -21,6 +21,8 @@ import (
 	"log"
 )
 
+const localhost = "127.0.0.1"
+
 var logFatal = log.Fatal
 
 func main() {

--- a/cli/root.go
+++ b/cli/root.go
@@ -47,6 +47,10 @@ func logDebug(v ...interface{}) {
 	}
 }
 
+func logWarn(v ...interface{}) {
+	log.Println(v...)
+}
+
 func getRootCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "go-imapgrab",
@@ -60,15 +64,15 @@ func getRootCmd() *cobra.Command {
 var rootCmd = getRootCmd()
 
 func init() {
-	initRootFlags(rootCmd)
+	initRootFlags(rootCmd, &rootConf)
 }
 
-func initRootFlags(rootCmd *cobra.Command) {
-	pflags := rootCmd.PersistentFlags()
+func initRootFlags(rootCmd *cobra.Command, rootConf *rootConfigT) {
+	flags := rootCmd.Flags()
 
-	pflags.StringVarP(&rootConf.server, "server", "s", "", "address of imap server")
-	pflags.IntVarP(&rootConf.port, "port", "p", defaultPort, "login port for imap server")
-	pflags.StringVarP(&rootConf.username, "user", "u", "", "login user name")
-	pflags.BoolVarP(&verbose, "verbose", "v", false, "verbose output")
-	pflags.BoolVarP(&noKeyring, "no-keyring", "k", false, "do not use the system keyring")
+	flags.StringVarP(&rootConf.server, "server", "s", "", "address of imap server")
+	flags.IntVarP(&rootConf.port, "port", "p", defaultPort, "login port for imap server")
+	flags.StringVarP(&rootConf.username, "user", "u", "", "login user name")
+	flags.BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	flags.BoolVarP(&noKeyring, "no-keyring", "k", false, "do not use the system keyring")
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -47,10 +47,6 @@ func logDebug(v ...interface{}) {
 	}
 }
 
-func logWarn(v ...interface{}) {
-	log.Println(v...)
-}
-
 func getRootCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "go-imapgrab",

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestRootCommand(t *testing.T) {
 	rootCmd := getRootCmd()
-	initRootFlags(rootCmd)
+	initRootFlags(rootCmd, &rootConfigT{})
 	err := rootCmd.Execute()
 	assert.NoError(t, err)
 }

--- a/cli/system_test.go
+++ b/cli/system_test.go
@@ -1,0 +1,97 @@
+/* A re-implementation of the amazing imapgrap in plain Golang.
+Copyright (C) 2022  Torsten Long
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/emersion/go-imap/backend/memory"
+	"github.com/emersion/go-imap/server"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Set up a fake, in-memory mail server that has exactly one mailbox "INBOX" for a user with user
+// name "username" and password "password". That one mailbox contains exactly one email.
+func setUpFakeServerAndCommand(t *testing.T, args []string) (func() error, func()) {
+	addr := "127.0.0.1:30218"
+
+	backend := memory.New()
+	srv := server.New(backend)
+
+	// Allow unauthenticated connections for testing.
+	srv.AllowInsecureAuth = true
+	// Listen on a high local port and only on locahost. This is a test server, which means we
+	// should not listen on all interfaces.
+	srv.Addr = addr
+
+	// Have server listen in separate goroutine to be able to handle requests asyncronously.
+	go func() {
+		err := srv.ListenAndServe()
+		require.NoError(t, err)
+	}()
+
+	var rootConf rootConfigT
+	var downloadConf downloadConfigT
+
+	var cmd *cobra.Command
+	switch args[0] {
+	case "root":
+		cmd = getRootCmd()
+		initRootFlags(cmd, &rootConf)
+	case "list":
+		// Always disable the keyring by making this a test run.
+		cmd = getListCmd(&rootConf, nil, false, &corer{})
+		initRootFlags(cmd, &rootConf)
+	case "download":
+		// Always disable the keyring by making this a test run.
+		cmd = getDownloadCmd(&rootConf, &downloadConf, nil, false, &corer{}, lock)
+		initRootFlags(cmd, &rootConf)
+		initDownloadFlags(cmd, &downloadConf)
+	}
+
+	// Make sure the arguments used for the test run are known to the command.
+	err := cmd.ParseFlags(args)
+	require.NoError(t, err)
+
+	execute := func() error {
+		return cmd.Execute()
+	}
+
+	cleanup := func() {
+		err := srv.Close()
+		require.NoError(t, err)
+	}
+
+	return execute, cleanup
+}
+
+func TestSystemSuccess(t *testing.T) {
+	t.Setenv("IGRAB_PASSWORD", "password")
+
+	args := []string{
+		"list", "--server=127.0.0.1", "--port=30218", "--user=username", "-v",
+	}
+
+	execute, cleanup := setUpFakeServerAndCommand(t, args)
+	defer cleanup()
+
+	err := execute()
+	assert.NoError(t, err)
+}

--- a/cli/system_test.go
+++ b/cli/system_test.go
@@ -18,34 +18,111 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
+	"log"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/emersion/go-imap/backend/memory"
+	"github.com/emersion/go-imap/client"
 	"github.com/emersion/go-imap/server"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func catchStdoutStderr(t *testing.T) func() (string, string) {
+	t.Helper()
+
+	// Automatically restore the old streams.
+	orgStdout := os.Stdout
+	orgStderr := os.Stderr
+	t.Cleanup(func() {
+		os.Stdout = orgStdout
+		os.Stderr = orgStderr
+		// Getting the current output for the log module is not possible. Thus, at the end of the
+		// test, we redirect logging to stderr, which it was originally.
+		log.SetOutput(orgStderr)
+	})
+
+	// Create a temporary file that will contain the new stdout and redirect.
+	fakeStdout := filepath.Join(t.TempDir(), "stdout")
+	stdout, err := os.Create(fakeStdout) //nolint:gosec
+	require.NoError(t, err)
+	os.Stdout = stdout
+
+	// Create a temporary file that will contain the new stderr and redirect.
+	fakeStderr := filepath.Join(t.TempDir(), "stderr")
+	stderr, err := os.Create(fakeStderr) //nolint:gosec
+	require.NoError(t, err)
+	os.Stderr = stderr
+	log.SetOutput(stderr)
+
+	t.Cleanup(func() {
+		err := stdout.Close()
+		require.NoError(t, err)
+		err = stderr.Close()
+		require.NoError(t, err)
+	})
+
+	// Create a function that, when called, reads the current values written to stdout and stderr
+	// and returns them. As we catch stdout and stderr, which are supposed to be human-readable, a
+	// string is the suitable return type instead of []byte.
+	readStdouterr := func() (string, string) {
+		stdout, err := os.ReadFile(fakeStdout) //nolint:gosec
+		require.NoError(t, err)
+		stderr, err := os.ReadFile(fakeStderr) //nolint:gosec
+		require.NoError(t, err)
+		return string(stdout), string(stderr)
+	}
+
+	return readStdouterr
+}
+
+func waitUntilConnected(t *testing.T, addr string) bool {
+	t.Helper()
+	// Give the server time to come up. Sadly, there is no way to actually detect whether the server
+	// is up other than connecting to it. Thus, we simply try to connect every now and again and
+	// sleep for some time in between.
+	connected := false
+	for try := 0; !connected && try < 100; try++ {
+		time.Sleep(time.Millisecond)
+		client, err := client.Dial(addr)
+		if err == nil {
+			connected = true
+			err := client.Logout()
+			require.NoError(t, err)
+		}
+	}
+	return connected
+}
+
 // Set up a fake, in-memory mail server that has exactly one mailbox "INBOX" for a user with user
 // name "username" and password "password". That one mailbox contains exactly one email.
-func setUpFakeServerAndCommand(t *testing.T, args []string) (func() error, func()) {
-	addr := "127.0.0.1:30218"
-
-	backend := memory.New()
-	srv := server.New(backend)
-
+func setUpFakeServerAndCommand(
+	t *testing.T, args []string,
+) (func() error, func() (string, string)) {
+	t.Helper()
+	server := server.New(memory.New())
 	// Allow unauthenticated connections for testing.
-	srv.AllowInsecureAuth = true
+	server.AllowInsecureAuth = true
 	// Listen on a high local port and only on locahost. This is a test server, which means we
 	// should not listen on all interfaces.
-	srv.Addr = addr
+	server.Addr = "127.0.0.1:30218"
 
-	// Have server listen in separate goroutine to be able to handle requests asyncronously.
+	// Have server listen in separate goroutine to be able to handle requests asyncronously. The
+	// channel is used to ensure the server stops listening before the main goroutine finishes
+	// execution.
+	syncChan := make(chan bool)
+	var serverErr error
 	go func() {
-		err := srv.ListenAndServe()
-		require.NoError(t, err)
+		serverErr = server.ListenAndServe()
+		syncChan <- true
 	}()
+	if !waitUntilConnected(t, server.Addr) {
+		t.Fatal("cannot connect to the fake server in time")
+	}
 
 	var rootConf rootConfigT
 	var downloadConf downloadConfigT
@@ -54,44 +131,82 @@ func setUpFakeServerAndCommand(t *testing.T, args []string) (func() error, func(
 	switch args[0] {
 	case "root":
 		cmd = getRootCmd()
-		initRootFlags(cmd, &rootConf)
 	case "list":
 		// Always disable the keyring by making this a test run.
 		cmd = getListCmd(&rootConf, nil, false, &corer{})
-		initRootFlags(cmd, &rootConf)
 	case "download":
 		// Always disable the keyring by making this a test run.
 		cmd = getDownloadCmd(&rootConf, &downloadConf, nil, false, &corer{}, lock)
-		initRootFlags(cmd, &rootConf)
 		initDownloadFlags(cmd, &downloadConf)
 	}
+	// All commands use the root flags.
+	initRootFlags(cmd, &rootConf)
 
 	// Make sure the arguments used for the test run are known to the command.
 	err := cmd.ParseFlags(args)
 	require.NoError(t, err)
 
-	execute := func() error {
-		return cmd.Execute()
-	}
+	stdouterrGetter := catchStdoutStderr(t)
 
 	cleanup := func() {
-		err := srv.Close()
+		err := server.Close()
 		require.NoError(t, err)
+		<-syncChan
+		if serverErr != nil {
+			require.ErrorContains(t, serverErr, "use of closed network connection")
+		}
 	}
+	t.Cleanup(cleanup)
 
-	return execute, cleanup
+	return cmd.Execute, stdouterrGetter
 }
 
-func TestSystemSuccess(t *testing.T) {
+func TestSystemListSuccess(t *testing.T) {
 	t.Setenv("IGRAB_PASSWORD", "password")
 
-	args := []string{
-		"list", "--server=127.0.0.1", "--port=30218", "--user=username", "-v",
-	}
+	args := []string{"list", "--server=127.0.0.1", "--port=30218", "--user=username", "-v"}
 
-	execute, cleanup := setUpFakeServerAndCommand(t, args)
-	defer cleanup()
+	execute, stdouterr := setUpFakeServerAndCommand(t, args)
 
 	err := execute()
 	assert.NoError(t, err)
+	stdout, stderr := stdouterr()
+	assert.Equal(t, "INBOX\n", stdout)
+	assert.Contains(t, stderr, "INFO retrieving folders")
+	assert.Contains(t, stderr, "INFO retrieved 1 folders")
+}
+
+func TestSystemListAuthError(t *testing.T) {
+	t.Setenv("IGRAB_PASSWORD", "password")
+
+	args := []string{"list", "--server=127.0.0.1", "--port=30218", "--user=something-else", "-v"}
+
+	execute, stdouterr := setUpFakeServerAndCommand(t, args)
+
+	err := execute()
+	assert.ErrorContains(t, err, "Bad username or password")
+	stdout, stderr := stdouterr()
+	assert.Equal(t, "\n", stdout)
+	assert.Contains(t, stderr, "ERROR cannot log in")
+}
+
+func TestSystemDownloadSuccess(t *testing.T) {
+	t.Setenv("IGRAB_PASSWORD", "password")
+	maildir := t.TempDir()
+
+	args := []string{
+		"download", "--server=127.0.0.1", "--port=30218", "--user=username", "-v", "--folder=_ALL_",
+		"--path", maildir,
+	}
+
+	execute, stdouterr := setUpFakeServerAndCommand(t, args)
+
+	err := execute()
+	assert.NoError(t, err)
+	stdout, stderr := stdouterr()
+	assert.Equal(t, "", stdout)
+	assert.Equal(t, "", stderr)
+
+	// Ensure that the maildir looks as expected.
+	// TODO
 }

--- a/core/core.go
+++ b/core/core.go
@@ -30,6 +30,7 @@ type IMAPConfig struct {
 	Port     int
 	User     string
 	Password string
+	Insecure bool
 }
 
 // ImapgrabOps provides functionality for interacting with the basic imapgrab functionality such as

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/emersion/go-imap"
@@ -30,10 +31,21 @@ const (
 	messageRetrievalBuffer = 20
 )
 
-// Make this a function pointer to simplify testing.
-var newImapClient = func(addr string) (imapOps, error) {
-	// Use automatic configuration of TLS options.
-	return client.DialTLS(addr, nil)
+// Make this a function pointer to simplify testing. Also takes a boolean to decide whether to use
+// secure auth nor not (i.e. TLS). This errors out if insecure auth is chossen but anything other
+// than "127.0.0.1" is passed as "addr".
+var newImapClient = func(addr string, insecure bool) (imap imapOps, err error) {
+	if !insecure {
+		// Use automatic configuration of TLS options.
+		imap, err = client.DialTLS(addr, nil)
+	} else if strings.HasPrefix(addr, "127.0.0.1:") {
+		err = fmt.Errorf(
+			"not allowing insecure auth for non-localhost address %s, use 127.0.0.1", addr,
+		)
+	} else {
+		imap, err = client.Dial(addr)
+	}
+	return
 }
 
 type imapOps interface {
@@ -54,7 +66,7 @@ func authenticateClient(config IMAPConfig) (imapClient imapOps, err error) {
 
 	logInfo(fmt.Sprintf("connecting to server %s", config.Server))
 	serverWithPort := fmt.Sprintf("%s:%d", config.Server, config.Port)
-	if imapClient, err = newImapClient(serverWithPort); err != nil {
+	if imapClient, err = newImapClient(serverWithPort, config.Insecure); err != nil {
 		logError("cannot connect")
 		return nil, err
 	}

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -38,11 +38,12 @@ var newImapClient = func(addr string, insecure bool) (imap imapOps, err error) {
 	if !insecure {
 		// Use automatic configuration of TLS options.
 		imap, err = client.DialTLS(addr, nil)
-	} else if strings.HasPrefix(addr, "127.0.0.1:") {
+	} else if !strings.HasPrefix(addr, "127.0.0.1:") {
 		err = fmt.Errorf(
 			"not allowing insecure auth for non-localhost address %s, use 127.0.0.1", addr,
 		)
 	} else {
+		logWarning("using insecure connection to locahost")
 		imap, err = client.Dial(addr)
 	}
 	return


### PR DESCRIPTION
This PR adds system tests using a fake in-memory IMAP server provided by the
`go-imap` package. Some changes are also introduced that are required for the
system tests such as:

* the ability to disable TLS for connections to localhost
* avoid using global flags for cobra commands but adding all flags to each
  individual command
* bug fixes that caused all commands to always set global flags instead of
  provided ones
