### PR TITLE
Ensure flags are always available & add system test for login command

### DIFF
--- a/cli/download.go
+++ b/cli/download.go
@@ -80,15 +80,14 @@ func getDownloadCmd(
 			return initCredentials(rootConf, disableKeyring, keyring)
 		},
 	}
-
+	initDownloadFlags(cmd, downloadConf)
+	initRootFlags(cmd, rootConf)
 	return cmd
 }
 
 var downloadCmd = getDownloadCmd(&rootConf, &downloadConf, defaultKeyring, true, &corer{}, lock)
 
 func init() {
-	initDownloadFlags(downloadCmd, &downloadConf)
-	initRootFlags(downloadCmd, &rootConf)
 	rootCmd.AddCommand(downloadCmd)
 }
 

--- a/cli/list.go
+++ b/cli/list.go
@@ -57,13 +57,12 @@ func getListCmd(
 			return initCredentials(rootConf, disableKeyring, keyring)
 		},
 	}
-
+	initRootFlags(cmd, rootConf)
 	return cmd
 }
 
 var listCmd = getListCmd(&rootConf, defaultKeyring, true, &corer{})
 
 func init() {
-	initRootFlags(listCmd, &rootConf)
 	rootCmd.AddCommand(listCmd)
 }

--- a/cli/login.go
+++ b/cli/login.go
@@ -50,13 +50,12 @@ func getLoginCmd(
 			return err
 		},
 	}
-
+	initRootFlags(cmd, rootConf)
 	return cmd
 }
 
 var loginCmd = getLoginCmd(&rootConf, defaultKeyring, term.ReadPassword)
 
 func init() {
-	initRootFlags(loginCmd, &rootConf)
 	rootCmd.AddCommand(loginCmd)
 }

--- a/cli/login_test.go
+++ b/cli/login_test.go
@@ -26,12 +26,7 @@ import (
 )
 
 func TestLoginSuccess(t *testing.T) {
-	rootConf := rootConfigT{
-		server:   "server",
-		port:     42,
-		username: "user",
-		password: "i do not matter",
-	}
+	rootConf := rootConfigT{password: "i do not matter"}
 	calledReadPassword := false
 	readPasswordFn := func(fd int) ([]byte, error) {
 		// We read from stdin.
@@ -47,6 +42,7 @@ func TestLoginSuccess(t *testing.T) {
 	mk.On("Set", "go-imapgrab/user@server:42", user.Username, "some password").Return(nil)
 
 	cmd := getLoginCmd(&rootConf, mk, readPasswordFn)
+	cmd.SetArgs([]string{"login", "--server=server", "--port=42", "--user=user"})
 	err = cmd.Execute()
 
 	assert.NoError(t, err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -48,20 +48,17 @@ func logDebug(v ...interface{}) {
 }
 
 func getRootCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "go-imapgrab",
 		Short: "Backup your IMAP-based email accounts with ease.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
+	return cmd
 }
 
 var rootCmd = getRootCmd()
-
-func init() {
-	initRootFlags(rootCmd, &rootConf)
-}
 
 func initRootFlags(rootCmd *cobra.Command, rootConf *rootConfigT) {
 	flags := rootCmd.Flags()

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestRootCommand(t *testing.T) {
 	rootCmd := getRootCmd()
-	initRootFlags(rootCmd, &rootConfigT{})
 	err := rootCmd.Execute()
 	assert.NoError(t, err)
 }

--- a/cli/system_test.go
+++ b/cli/system_test.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -171,6 +172,18 @@ func setUpFakeServerAndCommand(t *testing.T, args []string) func() error {
 	case "download":
 		// Always disable the keyring by making this a test run.
 		cmd = getDownloadCmd(&rootConf, &downloadConf, nil, false, &corer{}, lock)
+	case "login":
+		user, err := user.Current()
+		require.NoError(t, err)
+		mk := &mockKeyring{}
+		mk.On("Set", "go-imapgrab/username@127.0.0.1:30218", user.Name, "password").Return(nil)
+		t.Cleanup(func() { mk.AssertExpectations(t) })
+		cmd = getLoginCmd(
+			&rootConf, mk, func(int) ([]byte, error) { return []byte("password"), nil },
+		)
+	default:
+		t.Log("unknown command")
+		t.FailNow()
 	}
 
 	// Make sure the arguments used for the test run are known to the command.
@@ -290,4 +303,22 @@ func TestSystemDownloadSuccess(t *testing.T) {
 	for _, msg := range defaultExpectedDownloadTestLogs {
 		assert.Contains(t, stderr, msg)
 	}
+}
+
+func TestSystemLoginSuccess(t *testing.T) {
+	args := []string{"login", "--server=127.0.0.1", "--port=30218", "--user=username", "--verbose"}
+
+	stdouterr := catchStdoutStderr(t)
+	execute := setUpFakeServerAndCommand(t, args)
+
+	err := execute()
+	require.NoError(t, err)
+
+	stdout, stderr := stdouterr()
+
+	assert.Contains(t, stdout, "Please provide your password for the following service:")
+	assert.Contains(t, stdout, "Username: username")
+	assert.Contains(t, stdout, "Server: 127.0.0.1")
+	assert.Contains(t, stdout, "Port: 30218")
+	assert.Empty(t, stderr)
 }

--- a/cli/system_test.go
+++ b/cli/system_test.go
@@ -176,7 +176,7 @@ func setUpFakeServerAndCommand(t *testing.T, args []string) func() error {
 		user, err := user.Current()
 		require.NoError(t, err)
 		mk := &mockKeyring{}
-		mk.On("Set", "go-imapgrab/username@127.0.0.1:30218", user.Name, "password").Return(nil)
+		mk.On("Set", "go-imapgrab/username@127.0.0.1:30218", user.Username, "password").Return(nil)
 		t.Cleanup(func() { mk.AssertExpectations(t) })
 		cmd = getLoginCmd(
 			&rootConf, mk, func(int) ([]byte, error) { return []byte("password"), nil },

--- a/cli/system_test.go
+++ b/cli/system_test.go
@@ -186,9 +186,7 @@ func setUpFakeServerAndCommand(t *testing.T, args []string) func() error {
 		t.FailNow()
 	}
 
-	// Make sure the arguments used for the test run are known to the command.
-	err := cmd.ParseFlags(args)
-	require.NoError(t, err)
+	cmd.SetArgs(args)
 
 	t.Cleanup(func() {
 		err := server.Close()

--- a/cli/system_test.go
+++ b/cli/system_test.go
@@ -171,10 +171,7 @@ func setUpFakeServerAndCommand(t *testing.T, args []string) func() error {
 	case "download":
 		// Always disable the keyring by making this a test run.
 		cmd = getDownloadCmd(&rootConf, &downloadConf, nil, false, &corer{}, lock)
-		initDownloadFlags(cmd, &downloadConf)
 	}
-	// All commands use the root flags.
-	initRootFlags(cmd, &rootConf)
 
 	// Make sure the arguments used for the test run are known to the command.
 	err := cmd.ParseFlags(args)


### PR DESCRIPTION
This PR adds a system test for the login command to prevent a bug like the one in
the 0.5.1 release, i.e. that a command was missing some flags. Also move the
code adding the flags closer to the location where the commands are being
initialised.
