### PR TITLE
Minor fix to avoid an IMAP FETCH error when attempting to retrieve (non-existent) UUIDS for messages in an empty folder

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -17,7 +17,7 @@ update-deps:
 .PHONY: build
 build: go-imapgrab
 
-go-imapgrab: *.go go.*
+go-imapgrab: *.go go.* ../core/*.go
 	CGO_ENABLED=$(CGO_ENABLED) go build -o go-imapgrab ./...
 
 .PHONY: lint

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -226,6 +226,11 @@ func getAllMessageUUIDs(
 	logInfo("retrieving information about emails stored on server")
 	uids = make([]uidExt, 0, mbox.Messages)
 
+	// Return empty array instead of performing invalid FETCH for zero message UUIDS (empty folder)
+	if mbox.Messages == 0 {
+		return uids, nil
+	}
+
 	// Retrieve information about all emails.
 	seqset := new(imap.SeqSet)
 	seqset.AddRange(1, mbox.Messages)


### PR DESCRIPTION
When attempting a `download` operation and specifying an empty folder on the IMAP server, the program exited with an error `Error in IMAP command FETCH: Invalid messageset`:

```
$ export IGRAB_PASSWORD=mypassword
$ go-imapgrab download --no-keyring --server imap.example.com --user user@example.com --path ~/tmp/ --verbose --folder myemptyfolder

...

2025/02/12 15:22:49 INFO selecting folder:myemptyfolder
2025/02/12 15:22:49 INFO flags for selected folder are[\Answered \Flagged \Deleted \Seen \Draft $Forwarded Forwarded Redirected $NotJunk JunkRecorded NotJunk $MailFlagBit0 $MailFlagBit1]
2025/02/12 15:22:49 INFO selected folder contains 0 emails
2025/02/12 15:22:49 INFO retrieving information about emails stored on server
2025/02/12 15:22:49 INFO received information for 0 emails
2025/02/12 15:22:49 INFO will download 0 new emails
2025/02/12 15:22:49 ERROR Error in IMAP command FETCH: Invalid messageset (0.001 + 0.000 secs).
2025/02/12 15:22:49 INFO terminating connection
imap/client: 2025/02/12 15:22:49 error reading response: read tcp 192.168.1.3:62744->187.95.14.199:993: use of closed network connection
Error: 1 errors detected: Error in IMAP command FETCH: Invalid messageset (0.001 + 0.000 secs).
```

I traced the problem to the `getAllMessageUUIDs()` function and the fact it was sending a FETCH request to get UUIDs for messages from an empty folder.
This PR adds a small fix to simply return an empty array of UUIDs when there are no messages, which fixed the problem for me.

Cheers.