### PR TITLE
fix/attempting to fetch empty folders

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -17,7 +17,7 @@ update-deps:
 .PHONY: build
 build: go-imapgrab
 
-go-imapgrab: *.go go.*
+go-imapgrab: *.go go.* ../core/*.go
 	CGO_ENABLED=$(CGO_ENABLED) go build -o go-imapgrab ./...
 
 .PHONY: lint

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -17,7 +17,7 @@ update-deps:
 .PHONY: build
 build: go-imapgrab
 
-go-imapgrab: *.go go.* ../core/*.go
+go-imapgrab: *.go go.* ../core/*.go ../core/go.*
 	CGO_ENABLED=$(CGO_ENABLED) go build -o go-imapgrab ./...
 
 .PHONY: lint

--- a/core/download_test.go
+++ b/core/download_test.go
@@ -296,7 +296,7 @@ func TestDownloaderSelectFolder(t *testing.T) {
 
 func TestDownloaderGetAllMessageUUIDs(t *testing.T) {
 	mbox := &imap.MailboxStatus{
-		Messages: 0,
+		Messages: 1,
 	}
 	m := &mockClient{}
 	m.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("some error"))
@@ -308,6 +308,24 @@ func TestDownloaderGetAllMessageUUIDs(t *testing.T) {
 	_, err := dl.getAllMessageUUIDs(mbox)
 
 	assert.Error(t, err)
+}
+
+func TestDownloaderGetAllMessageUUIDsNotFetchingEmptyFolder(t *testing.T) {
+	mbox := &imap.MailboxStatus{
+		Messages: 0,
+	}
+	m := &mockClient{}
+	// We error out here.
+	m.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("some error"))
+	dl := &downloader{
+		imapOps:    m,
+		deliverOps: nil,
+	}
+
+	_, err := dl.getAllMessageUUIDs(mbox)
+
+	// But the mock is not being called because the folder is empty.
+	assert.NoError(t, err)
 }
 
 func TestDownloaderStreamingOldmailWriteout(t *testing.T) {

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -226,6 +226,11 @@ func getAllMessageUUIDs(
 	logInfo("retrieving information about emails stored on server")
 	uids = make([]uidExt, 0, mbox.Messages)
 
+	// Return empty array instead of performing invalid FETCH for zero message UUIDS (empty folder)
+	if mbox.Messages == 0 {
+		return uids, nil
+	}
+
 	// Retrieve information about all emails.
 	seqset := new(imap.SeqSet)
 	seqset.AddRange(1, mbox.Messages)

--- a/core/imap_client.go
+++ b/core/imap_client.go
@@ -224,12 +224,12 @@ func getAllMessageUUIDs(
 	mbox *imap.MailboxStatus, imapClient imapOps,
 ) (uids []uidExt, err error) {
 	logInfo("retrieving information about emails stored on server")
-	uids = make([]uidExt, 0, mbox.Messages)
-
-	// Return empty array instead of performing invalid FETCH for zero message UUIDS (empty folder)
+	// Handle the special case of empty folders by returning early.
 	if mbox.Messages == 0 {
-		return uids, nil
+		return nil, nil
 	}
+
+	uids = make([]uidExt, 0, mbox.Messages)
 
 	// Retrieve information about all emails.
 	seqset := new(imap.SeqSet)


### PR DESCRIPTION
- **fix: skip invalid IMAP FETCH of message UUIDs for empty folders**
- **fix: add core/*.go files as dependencies for go-imapgrab build target**
- **Minor changes to suggested fix**
